### PR TITLE
rename mount to ruleset

### DIFF
--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -14,7 +14,7 @@ which is appdirs.user_data_dir.
 * `$REPO/ick.toml`
 * `$REPO/pyproject.toml`
 
-Any of these can define a `[[mount]]`, as detailed below.
+Any of these can define one or more `[[ruleset]]` sections, as detailed below.
 
 Additionally, project-level configs are read for `do_not_want` and not much
 else.
@@ -23,17 +23,17 @@ else.
 * `$PROJECT/pyproject.toml`
 
 
-## Mounts
+## Rulesets
 
-A mount is a reference to a dir or repo url that contains more `ick.toml` files
-that define hooks or collections, and can contain arbitrary other files that we
+A ruleset is a directory or repo url that contains more `ick.toml` files
+that define hooks and can contain arbitrary other files that we
 want to exist on the filesystem (for example, compiled Go binaries).
 
 The syntax with the doubled square brackets is called an [Array of
 Tables](https://toml.io/en/v1.0.0#array-of-tables).
 
 ```toml
-[[mount]]
+[[ruleset]]
 url = "https://github.com/thatch/hobbyhorse"
 prefix = "hh/"
 ```
@@ -41,7 +41,7 @@ prefix = "hh/"
 (or in `pyproject.toml`)
 
 ```toml
-[[tool.ick.mount]]
+[[tool.ick.ruleset]]
 url = "https://github.com/thatch/hobbyhorse"
 prefix = "hh/"
 ```

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -7,7 +7,7 @@ incrementally from individual files into one big file, like `isort.ini` ->
 First, decide what language your rule is going to be written in.  I happen to
 know that you could do this in Python, but maybe you've got something else.
 
-## Setting up a local development mount
+## Setting up a local development ruleset
 
 To avoid getting into the weeds on the many ways to configure it, let's assume
 you have an empty directory `/tmp/foo` (adjust command lines as needed) that you
@@ -16,7 +16,7 @@ want to put your rule in.
 First you'll need to create a user/repo-type config in `ick.toml` in your Python project's root:
 
 ```toml
-[[mount]]
+[[ruleset]]
 
 path = "."
 ```

--- a/ick.toml
+++ b/ick.toml
@@ -4,5 +4,5 @@
 #
 # to ignore your user config and parse just these hooks.
 
-[[mount]]
+[[ruleset]]
 path = "meta/"

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -31,7 +31,7 @@ def discover_rules(rtc: RuntimeConfig) -> Sequence[RuleConfig]:
     rules: list[RuleConfig] = []
 
     mounts = {}
-    for mount in rtc.rules_config.mount:
+    for mount in rtc.rules_config.ruleset:
         LOG.log(VLOG_1, "Processing %s", mount)
         # Prefixes should be unique; they override here
         mounts[mount.prefix] = load_rule_repo(mount)

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -26,10 +26,10 @@ LOG = getLogger(__name__)
 class RulesConfig(Struct):
     """ """
 
-    mount: Sequence[Mount] = ()
+    ruleset: Sequence[Mount] = ()
 
     def inherit(self, less_specific_defaults):
-        self.mount = merge(self.mount, less_specific_defaults.mount)
+        self.ruleset = merge(self.ruleset, less_specific_defaults.ruleset)
 
 
 class Mount(Struct):
@@ -144,7 +144,7 @@ def load_rules_config(cur: Path, isolated_repo: bool) -> RulesConfig:
             else:
                 c = decode_toml(p.read_bytes(), type=RulesConfig)
 
-            for mount in c.mount:
+            for mount in c.ruleset:
                 mount.base_path = p.parent
 
             # TODO finalize mount paths so relative works

--- a/tests/test_config_hook_repo.py
+++ b/tests/test_config_hook_repo.py
@@ -39,6 +39,6 @@ def test_get_impl():
 
 def test_discover():
     m = Mount(base_path=Path.cwd(), path="tests/fixture_rules")
-    h = RulesConfig(mount=[m])
+    h = RulesConfig(ruleset=[m])
     rules = discover_rules(rtc=RuntimeConfig(main_config=MainConfig(), rules_config=h, settings=Settings()))
     assert len(rules) == 3


### PR DESCRIPTION
Only in the user-visible parts, didn't rename internal classes etc.