### PR TITLE
Avoid user-level config in scenario tests

### DIFF
--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -34,6 +34,10 @@ def clean_output(output: str) -> str:
 
 @pytest.mark.parametrize("filename", SCENARIOS)
 def test_scenario(filename, monkeypatch):
+
+    # An easy way to avoid user-level config affecting tests
+    monkeypatch.setenv("XDG_CONFIG_HOME", "/")
+
     path = SCENARIO_DIR / filename
     commands = load_scenario(path)
     update = bool(int(os.getenv("UPDATE_SCENARIOS", "0")))


### PR DESCRIPTION
Couldn't figure out an easy way to test this one.

Notes:
1. It might make sense to pretend that `tests/fixture_rules` is user-level config (but that will require regenerating the scenarios)
2. We don't yet find a system-level config (like in /etc), but probably should separately
3. We *could* use `-I` here (and that's actually why I added it) but then we can't test config inheritance someday.
4. We *can't* use `ICK_CONFIG` here because then we don't look at repo config.  (This is modeled after, among other things, the way `uv` works)