### PR TITLE
Complete test-rules refactor

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -285,10 +285,15 @@ any tests yet, so it has nothing to do:
 <!-- [[[cog show_cmd("ick test-rules", columns=999) ]]] -->
 ```shell
 $ ick test-rules
-no tests for ./move_isort_cfg under /tmp/foo/move_isort_cfg/tests
-Prepare ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+testing...
+  ./move_isort_cfg: <no-test> PASS
+
+FAILS
+
+./move_isort_cfg: no tests in /tmp/foo/move_isort_cfg/tests
+(exited with 1)
 ```
-<!-- [[[end]]] (sum: 1Cbae9GdeU) -->
+<!-- [[[end]]] (sum: wgvHHru5xr) -->
 
 In your `move_isort_cfg` rule directory, create a `tests` subdirectory.  There
 each directory will be a test.  Create a `move_isort_cfg/tests/no_isort`
@@ -336,11 +341,10 @@ This is a simple test that checks that if there is no `isort.cfg` file, the
 <!-- [[[cog show_cmd("ick test-rules") ]]] -->
 ```shell
 $ ick test-rules
-1 ok
-Prepare          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-./move_isort_cfg ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
+testing...
+  ./move_isort_cfg: . PASS
 ```
-<!-- [[[end]]] (sum: HXGRqdSY1X) -->
+<!-- [[[end]]] (sum: aPmBG+QcQb) -->
 
 Now make a more realistic test. Create a `change_made`
 directory in the `tests` directory. Create these files:
@@ -382,9 +386,7 @@ Now `ick test-rules` shows two tests passing:
 <!-- [[[cog show_cmd("ick test-rules") ]]] -->
 ```shell
 $ ick test-rules
-1 ok
-1 ok
-Prepare          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-./move_isort_cfg ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
+testing...
+  ./move_isort_cfg: .. PASS
 ```
-<!-- [[[end]]] (sum: 6lHyiNHy6X) -->
+<!-- [[[end]]] (sum: Q8fKoyhhcW) -->

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from typing import Optional
 
@@ -75,7 +76,7 @@ def test_rules(ctx):
     Run self-tests against all rules.
     """
     r = Runner(ctx.obj, ctx.obj.repo)
-    r.test_rules()
+    sys.exit(r.test_rules())
 
 
 @main.command()

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -1,8 +1,11 @@
 from __future__ import annotations
 
 import collections
+import io
 import re
-from concurrent.futures import ThreadPoolExecutor, as_completed
+import sys
+import traceback
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
 from fnmatch import fnmatch
 from glob import glob
@@ -15,7 +18,7 @@ from typing import Any, Iterable
 import moreorless
 from keke import ktrace
 from moreorless.combined import combined_diff
-from rich.progress import Progress
+from rich import print
 
 from ick_protocol import Finished, Modified
 
@@ -59,33 +62,71 @@ class Runner:
             i = get_impl(rule)(rule, self.rtc)
             yield i
 
-    def test_rules(self) -> None:
-        with ThreadPoolExecutor() as tpe, Progress() as progress:
-            outstanding = {}
-            prepare_key = progress.add_task("Prepare", total=None)
+    def test_rules(self) -> int:
+        """
+        Returns an exit code (0 on success)
+        """
+        with ThreadPoolExecutor() as tpe:
+            print("[dim]testing...[/dim]")
+            # It's about this point I realize that yes, I am writing a whole
+            # test runner and that's not the business I want to be in.  Oh
+            # well...
+            buffered_output = []
+
+            i = 0
             for rule_instance, names in self.iter_tests():
+                outstanding = {}
+                print(f"  [bold]{rule_instance.rule_config.qualname}[/bold]: ", end="")
                 rule_instance.prepare()
-                progress.update(prepare_key)
                 if not names:
-                    progress.console.print("no tests for", rule_instance.rule_config.qualname, "under", rule_instance.rule_config.test_path)
+                    print("<no-test>", end="")
+                    buffered_output.append(
+                        f"{rule_instance.rule_config.qualname}: [yellow]no tests[/yellow] in {rule_instance.rule_config.test_path}"
+                    )
                 else:
-                    key = progress.add_task(rule_instance.rule_config.qualname, total=len(names))
+                    key = str(i)
+                    i += 1
                     for n in names:
-                        outstanding[tpe.submit(self._perform_test, rule_instance, n)] = (key, rule_instance.rule_config.qualname)
+                        outstanding[tpe.submit(self._perform_test, rule_instance, n)] = (
+                            key,
+                            f"{rule_instance.rule_config.qualname} on {n}",
+                        )
 
-            progress.update(prepare_key, completed=True)
-            # breakpoint()
+                success = True
+                for fut in outstanding.keys():
+                    progress_key, desc = outstanding[fut]
+                    try:
+                        fut.result()
+                    except Exception as e:
+                        print("[red]F[/red]", end="")
+                        buffered_output.append(f"  {desc}:")
+                        # This should be combined with how we actually run
+                        # things...
+                        typ, value, tb = sys.exc_info()
+                        buf = io.StringIO()
+                        traceback.print_tb(tb, file=buf)
+                        # TODO redent
+                        buffered_output.append("  " + buf.getvalue())
+                        buffered_output.append(repr(e))
+                        success = False
+                    else:
+                        print(".", end="")
 
-            for fut in as_completed(outstanding.keys()):
-                progress_key, desc = outstanding[fut]
-                try:
-                    fut.result()
-                except Exception as e:
-                    progress.console.print(desc)
-                    progress.console.print("  " + repr(e))
+                # TODO try to line these up
+                if success:
+                    print(" [green]PASS[/green]")
                 else:
-                    progress.console.print(progress_key, "ok")
-                progress.update(progress_key, advance=1)
+                    print(" [red]FAIL[/red]")
+
+            if buffered_output:
+                print()
+                print("FAILS")
+                print()
+                for line in buffered_output:
+                    print(line)
+                return 1
+
+            return 0
 
     def _perform_test(self, rule_instance, test_path) -> None:
         with TemporaryDirectory() as td:
@@ -102,13 +143,17 @@ class Runner:
             bp = test_path / "b"
             files_to_check = set(glob("*", root_dir=bp, recursive=True))
             files_to_check.update(glob(".github/**", root_dir=bp, recursive=True))
+            files_to_check = {f for f in files_to_check if (bp / f).is_file()}
 
             response = self._run_one(rule_instance, repo, project)
-            assert isinstance(response[-1], Finished), "Last response is finished"
+            if not isinstance(response[-1], Finished):
+                raise AssertionError(f"Last response is not Finished: {response[-1].__class__.__name__}")
             if response[-1].error:
                 expected_path = bp / "output.txt"
                 if not expected_path.exists():
-                    assert False, f"missing output: {response[-1].message}"
+                    raise AssertionError(
+                        f"Test crashed, but {expected_path} doesn't exist so that seems unintended:\n" + response[-1].message
+                    )
 
                 expected = expected_path.read_text()
                 if expected != response[-1].message:
@@ -185,8 +230,12 @@ class Runner:
                             filenames = [f for f in filenames if any(fnmatch(f, x) for x in rule_instance.rule_config.inputs)]
 
                         resp.extend(work.run(rule_instance.rule_config.qualname, filenames))
-        except Exception as e:
-            resp = [Finished(rule_instance.rule_config.qualname, error=True, message=repr(e))]
+        except Exception:
+            typ, value, tb = sys.exc_info()
+            buf = io.StringIO()
+            traceback.print_tb(tb, file=buf)
+            print(repr(e), file=buf)
+            resp = [Finished(rule_instance.rule_config.qualname, error=True, message=buf.getvalue())]
         return resp
 
     @ktrace()

--- a/tests/scenarios/run_some/test_rules.txt
+++ b/tests/scenarios/run_some/test_rules.txt
@@ -1,5 +1,3 @@
 $ ick test-rules
-1 ok
-1 ok
-Prepare          ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-./move_isort_cfg ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━ 100% 0:00:00
+testing...
+  ./move_isort_cfg: .. PASS


### PR DESCRIPTION
Jadon asked if we could make this easier to understand, like how advice-animal did it.  We support multiple tests now, so... dots?

We no longer parallelize across a rule boundary, because it made the code simpler and running _some_ in parallel helps keep us honest.

CLI can now exit nonzero (as recorded in the tutorial change)