### PR TITLE
Add description and contact

### DIFF
--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -96,6 +96,9 @@ class RuleConfig(Struct):
     outputs: Optional[Sequence[str]] = None
     extra_inputs: Optional[Sequence[str]] = None
 
+    description: Optional[str] = None
+    contact: Optional[str] = None
+
 
 @ktrace()
 def load_rules_config(cur: Path, isolated_repo: bool) -> RulesConfig:

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -241,22 +241,24 @@ class Runner:
             #     duration = f" ({impl.rule_config.hours} {pl('hour', impl.rule_config.hours)})"
 
             msg = f"{impl.rule_config.qualname}{duration}"
+            if impl.rule_config.description:
+                msg += f": {impl.rule_config.description}"
             if not impl.runnable:
                 msg += f"  *** {impl.status}"
             for rule in impl.list().rule_names:
                 rules_by_urgency[impl.rule_config.urgency].append(msg)
 
         first = True
-        for u, rules in sorted(rules_by_urgency.items()):
+        for urgency_label, rules in sorted(rules_by_urgency.items()):
             if not first:
                 print()
             else:
                 first = False
 
-            print(u.name)
-            print("=" * len(str(u.name)))
-            for v in rules:
-                print(f"* {v}")
+            print(urgency_label.name)
+            print("=" * len(str(urgency_label.name)))
+            for rule in rules:
+                print(f"* {rule}")
 
 
 def pl(noun: str, count: int) -> str:

--- a/tests/scenarios/simple_list_rules/list_rules.txt
+++ b/tests/scenarios/simple_list_rules/list_rules.txt
@@ -6,5 +6,5 @@ LATER
 
 NOW
 ===
-* ./hello: Say hello
+* hello: Say hello
 

--- a/tests/scenarios/simple_list_rules/list_rules.txt
+++ b/tests/scenarios/simple_list_rules/list_rules.txt
@@ -6,4 +6,4 @@ LATER
 
 NOW
 ===
-* ./hello
+* ./hello: Say hello

--- a/tests/scenarios/simple_list_rules/list_rules.txt
+++ b/tests/scenarios/simple_list_rules/list_rules.txt
@@ -7,4 +7,3 @@ LATER
 NOW
 ===
 * hello: Say hello
-

--- a/tests/scenarios/simple_list_rules/repo/ick.toml
+++ b/tests/scenarios/simple_list_rules/repo/ick.toml
@@ -4,6 +4,7 @@ impl = "shell"
 command = "echo hi"
 scope = "repo"
 urgency = "now"
+description = "Say hello"
 
 [[rule]]
 name = "shouty"


### PR DESCRIPTION
I don't want things to get too verbose, so right now I just print the descriptions during `list-rules`.