### PR TITLE
Separate ERROR and FAIL states

### DIFF
--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -233,11 +233,12 @@ Now `ick run` shows a dry-run summary of the changes that would be made:
 <!-- [[[cog show_cmd("ick run") ]]] -->
 ```console
 $ ick run
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
      isort.cfg +0-3
      pyproject.toml +3-0
 ```
-<!-- [[[end]]] (sum: DAYg8v441H) -->
+<!-- [[[end]]] (sum: NMU6ekvaPt) -->
 
 Passing the `--patch` option displays the full patch of the changes that would
 be made:
@@ -245,7 +246,8 @@ be made:
 <!-- [[[cog show_cmd("ick run --patch") ]]] -->
 ```console
 $ ick run --patch
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
 diff --git isort.cfg isort.cfg
 deleted file mode 100644
 index fbab120..0000000
@@ -264,7 +266,7 @@ index e69de29..089c824 100644
 +line_length = "88"
 +multi_line_output = "3"
 ```
-<!-- [[[end]]] (sum: cujTI1b42k) -->
+<!-- [[[end]]] (sum: zy/3zowNaD) -->
 
 
 ## Reducing execution

--- a/docs/whole-tutorial.md
+++ b/docs/whole-tutorial.md
@@ -233,11 +233,12 @@ Now `ick run` shows a dry-run summary of the changes that would be made:
 <!-- [[[cog show_cmd("ick run") ]]] -->
 ```console
 $ ick run
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
      isort.cfg +0-3
      pyproject.toml +3-0
 ```
-<!-- [[[end]]] (sum: DAYg8v441H) -->
+<!-- [[[end]]] (sum: NMU6ekvaPt) -->
 
 Passing the `--patch` option displays the full patch of the changes that would
 be made:
@@ -245,7 +246,8 @@ be made:
 <!-- [[[cog show_cmd("ick run --patch") ]]] -->
 ```console
 $ ick run --patch
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
 diff --git isort.cfg isort.cfg
 deleted file mode 100644
 index fbab120..0000000
@@ -264,7 +266,7 @@ index e69de29..089c824 100644
 +line_length = "88"
 +multi_line_output = "3"
 ```
-<!-- [[[end]]] (sum: cujTI1b42k) -->
+<!-- [[[end]]] (sum: zy/3zowNaD) -->
 
 
 ## Reducing execution

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -135,8 +135,12 @@ def run(
         if not json_flag:
             where = f"on {result.project} " if result.project else ""
             print(f"-> [bold]{result.rule}[/bold] {where}", end="")
-            if result.finished.error:
+            if result.finished.status is None:
                 print("[red]ERROR[/red]")
+                for line in result.finished.message.splitlines():
+                    print("    ", line)
+            elif result.finished.status is False:
+                print("[yellow]FAIL[/yellow]")
                 for line in result.finished.message.splitlines():
                     print("    ", line)
             else:
@@ -146,12 +150,12 @@ def run(
             modifications = []
             for mod in result.modifications:
                 modifications.append({"file_name": mod.filename, "diff_stat": mod.diffstat})
-            error_message = result.finished.message if result.finished.error else None
             output = {
                 "project_name": result.project,
-                "ok_status": not result.finished.error,
+                "status": result.finished.status,
                 "modified": modifications,
-                "error_message": error_message,
+                # The meaning of this field depends on the status field above
+                "message": result.finished.message,
             }
             if result.rule not in results:
                 results[result.rule] = [output]

--- a/ick/git_diff.py
+++ b/ick/git_diff.py
@@ -1,6 +1,6 @@
 import subprocess
 from pathlib import Path
-from typing import Iterable
+from typing import Iterable, Optional
 
 from ick_protocol import Finished, Modified, Msg
 
@@ -12,6 +12,7 @@ def get_diff_messages(msg: str, rule_name: str, workdir: Path) -> Iterable[Msg]:
     plus_count = None
     minus_count = None
     filename = ""
+    status: Optional[bool] = True  # all's ok
 
     def get_chunk() -> Msg:
         new_bytes: bytes | None = None
@@ -20,6 +21,9 @@ def get_diff_messages(msg: str, rule_name: str, workdir: Path) -> Iterable[Msg]:
             new_bytes = Path(workdir, filename).read_bytes()
         except FileNotFoundError:
             pass
+
+        nonlocal status
+        status = False
 
         return Modified(
             rule_name=rule_name,
@@ -74,4 +78,4 @@ def get_diff_messages(msg: str, rule_name: str, workdir: Path) -> Iterable[Msg]:
     if buf:
         yield get_chunk()
 
-    yield Finished(error=False, rule_name=rule_name, message=msg)
+    yield Finished(status=status, rule_name=rule_name, message=msg)

--- a/ick_protocol/ick_protocol.py
+++ b/ick_protocol/ick_protocol.py
@@ -29,7 +29,7 @@ process (regular LSP just has "format_file").
 """
 
 from enum import Enum
-from typing import Sequence, Union
+from typing import Optional, Sequence, Union
 
 from msgspec import Struct
 from msgspec.structs import replace as replace
@@ -107,7 +107,16 @@ class Modified(Struct, tag_field="t", tag="M"):
 
 class Finished(Struct, tag_field="t", tag="F"):
     rule_name: str
-    error: bool
+
+    # * If the rule does not run to completion, status=None and the error info is
+    #   in message (ERROR, in unittest terms)
+    # * If the rule runs to completion and the code is already in the ideal
+    #   state, then status=True (PASS, in unittest terms)
+    # * If the rule runs to completion and the code needs help, then
+    #   status=False (FAIL, in unittest terms, regardless of whether there are
+    #   suggested modifications).
+    status: Optional[bool]
+
     # the entire rule is only allowed one message; it's used as the commit
     # message or displayed inline.
     message: str

--- a/tests/scenarios/json_flag/simple.txt
+++ b/tests/scenarios/json_flag/simple.txt
@@ -4,23 +4,23 @@ $ ick run --json
         "do_nothing": [
             {
                 "project_name": "",
-                "ok_status": true,
+                "status": true,
                 "modified": [],
-                "error_message": null
+                "message": "do_nothing"
             }
         ],
         "fail": [
             {
                 "project_name": "",
-                "ok_status": false,
+                "status": null,
                 "modified": [],
-                "error_message": "AssertionError\n"
+                "message": "AssertionError\n"
             }
         ],
         "move_a": [
             {
                 "project_name": "",
-                "ok_status": true,
+                "status": false,
                 "modified": [
                     {
                         "file_name": "file_a.cfg",
@@ -31,7 +31,7 @@ $ ick run --json
                         "diff_stat": "+3-0"
                     }
                 ],
-                "error_message": null
+                "message": "move_a"
             }
         ]
     }

--- a/tests/scenarios/project_finding/run.txt
+++ b/tests/scenarios/project_finding/run.txt
@@ -1,5 +1,5 @@
 $ ick run
--> show_ick_vars on python1/ ERROR
+-> show_ick_vars on python1/ FAIL
      ICK_REPO_PATH=/CWD
--> show_ick_vars on mono/java/ ERROR
+-> show_ick_vars on mono/java/ FAIL
      ICK_REPO_PATH=/CWD

--- a/tests/scenarios/run_some/run.txt
+++ b/tests/scenarios/run_some/run.txt
@@ -1,7 +1,8 @@
 $ ick run
 -> i_have_no_tests OK
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
      isort.cfg +0-3
      pyproject.toml +3-0
--> show_ick_vars ERROR
+-> show_ick_vars FAIL
      ICK_REPO_PATH=/CWD

--- a/tests/scenarios/run_some/run_patch.txt
+++ b/tests/scenarios/run_some/run_patch.txt
@@ -1,6 +1,7 @@
 $ ick run --patch
 -> i_have_no_tests OK
--> move_isort_cfg OK
+-> move_isort_cfg FAIL
+     move_isort_cfg
 diff --git isort.cfg isort.cfg
 deleted file mode 100644
 index fbab120..0000000
@@ -18,5 +19,5 @@ index e69de29..089c824 100644
 +[tool.isort]
 +line_length = "88"
 +multi_line_output = "3"
--> show_ick_vars ERROR
+-> show_ick_vars FAIL
      ICK_REPO_PATH=/CWD

--- a/tests/test_rules_ast_grep.py
+++ b/tests/test_rules_ast_grep.py
@@ -38,6 +38,6 @@ def test_ast_grep_works(tmp_path: Path) -> None:
 
     assert resp[1] == Finished(
         rule_name="ast-grep",
-        error=False,
+        status=False,
         message="ast-grep",
     )

--- a/tests/test_rules_docker.py
+++ b/tests/test_rules_docker.py
@@ -41,6 +41,6 @@ def test_basic_docker(tmp_path: Path) -> None:
 
     assert resp[1] == Finished(
         rule_name="foo",
-        error=False,
+        status=False,
         message="foo",
     )

--- a/tests/test_rules_merge_toml.py
+++ b/tests/test_rules_merge_toml.py
@@ -38,6 +38,6 @@ baz = 99
 
     assert resp[1] == Finished(
         rule_name="merge_toml",
-        error=False,
+        status=False,
         message="merge_toml",
     )

--- a/tests/test_rules_pygrep.py
+++ b/tests/test_rules_pygrep.py
@@ -36,6 +36,6 @@ def test_pygrep_works(tmp_path: Path) -> None:
 
     assert resp[1] == Finished(
         rule_name="pygrep",
-        error=False,
+        status=False,
         message="pygrep",
     )

--- a/tests/test_rules_python.py
+++ b/tests/test_rules_python.py
@@ -46,6 +46,6 @@ for f in sys.argv[1:]:
 
     assert resp[1] == Finished(
         rule_name="foo",
-        error=False,
+        status=False,
         message="foo",
     )

--- a/tests/test_rules_shell.py
+++ b/tests/test_rules_shell.py
@@ -59,7 +59,7 @@ def test_smoke_not_found(tmp_path: Path) -> None:
 
     assert len(resp) == 1
     assert isinstance(resp[0], Finished)
-    assert resp[0].error
+    assert resp[0].status is None
     assert "xargs: /bin/zzyzx: No such file or directory" in resp[0].message
 
 
@@ -81,7 +81,7 @@ def test_smoke_failure(tmp_path: Path) -> None:
 
     assert len(resp) == 1
     assert isinstance(resp[0], Finished)
-    assert resp[0].error
+    assert resp[0].status is None
     assert "returned non-zero exit status" in resp[0].message
 
 


### PR DESCRIPTION
Fairly significant json change, but I think this captures better what we'd like to see from a meta-runner -- FAIL means report to the user, ERROR means report to the rule writer :)