### PR TITLE
Recognize go.mod as a Go project marker

### DIFF
--- a/ick/config/main.py
+++ b/ick/config/main.py
@@ -37,6 +37,9 @@ DEFAULT_PROJECT_MARKERS = {
     "java": [
         "build.gradle",
     ],
+    "go": [
+        "go.mod",
+    ],
     # Since autodetected projects can't contain other projects, this caused
     # problems (docker-compose.yml at the root of the repo is fairly common).
     # "docker": [

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -41,12 +41,13 @@ def test_project_finder_marker_can_have_slashes() -> None:
 
 
 def test_project_finder_types() -> None:
-    sample_string = "a/pyproject.toml\0a/tests/pyproject.toml\0b/build.gradle\0"
+    sample_string = "a/pyproject.toml\0a/tests/pyproject.toml\0b/build.gradle\0c/go.mod\0"
     projects = find_projects(Repo(Path()), sample_string, MainConfig.DEFAULT)  # type: ignore[attr-defined] # FIX ME
 
-    # These two make the assertion failures easier to read
+    # These three make the assertion failures easier to read
     projects[0].repo = "FAKE"  # type: ignore[assignment]
     projects[1].repo = "FAKE"  # type: ignore[assignment]
+    projects[2].repo = "FAKE"  # type: ignore[assignment]
 
     assert to_builtins(projects[0]) == {
         "subdir": "a/",
@@ -58,5 +59,11 @@ def test_project_finder_types() -> None:
         "subdir": "b/",
         "marker_filename": "build.gradle",
         "typ": "java",
+        "repo": "FAKE",
+    }
+    assert to_builtins(projects[2]) == {
+        "subdir": "c/",
+        "marker_filename": "go.mod",
+        "typ": "go",
         "repo": "FAKE",
     }


### PR DESCRIPTION
Note to future self: go.mod is also a good indicator, but that's more like a lock file and is derived from go.mod.

People can of course add their own project types via config, but this one is obvious enough that we should handle it in the defaults.