### PR TITLE
Slimmed-down shell test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,4 +49,4 @@ mypy:
 
 .PHONY: test
 test:
-	pytest --cov=ick --cov=tests --cov-report=term-missing --cov-report=html
+	pytest --cov=ick --cov=tests --cov-report=term-missing --cov-report=html --cov-context=test

--- a/docs/getting-started/tutorial.md
+++ b/docs/getting-started/tutorial.md
@@ -73,11 +73,11 @@ but no files are changed:
 <!-- [[[cog show_cmd("ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run") ]]] -->
 ```console
 $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run
--> ick-tutorial-rules-1/move_isort_cfg OK
+-> ick-tutorial-rules-1/move_isort_cfg FAIL
      pyproject.toml +5-0
      isort.cfg +1-3
 ```
-<!-- [[[end]]] (sum: yReK0mLGhM)  -->
+<!-- [[[end]]] (sum: Ap8jhKLTlm)  -->
 
 This shows that isort.cfg would have three lines deleted, and pyproject.toml
 would have four lines added.
@@ -87,7 +87,7 @@ To see the full diff, use the `--patch` option:
 <!-- [[[cog show_cmd("ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --patch") ]]] -->
 ```console
 $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --patch
--> ick-tutorial-rules-1/move_isort_cfg OK
+-> ick-tutorial-rules-1/move_isort_cfg FAIL
 --- a/isort.cfg
 +++ b/isort.cfg
 @@ -1,3 +0,0 @@
@@ -105,7 +105,7 @@ $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --p
 +line_length = "88"
 +multi_line_output = "3"
 ```
-<!-- [[[end]]] (sum: pRsyXPoNgU)  -->
+<!-- [[[end]]] (sum: NSXvn3onvy)  -->
 
 [WHAT ELSE SHOULD GO HERE?]
 

--- a/docs/whole-tutorial.md
+++ b/docs/whole-tutorial.md
@@ -73,11 +73,11 @@ but no files are changed:
 <!-- [[[cog show_cmd("ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run") ]]] -->
 ```console
 $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run
--> ick-tutorial-rules-1/move_isort_cfg OK
+-> ick-tutorial-rules-1/move_isort_cfg FAIL
      pyproject.toml +5-0
      isort.cfg +1-3
 ```
-<!-- [[[end]]] (sum: yReK0mLGhM)  -->
+<!-- [[[end]]] (sum: Ap8jhKLTlm)  -->
 
 This shows that isort.cfg would have three lines deleted, and pyproject.toml
 would have four lines added.
@@ -87,7 +87,7 @@ To see the full diff, use the `--patch` option:
 <!-- [[[cog show_cmd("ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --patch") ]]] -->
 ```console
 $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --patch
--> ick-tutorial-rules-1/move_isort_cfg OK
+-> ick-tutorial-rules-1/move_isort_cfg FAIL
 --- a/isort.cfg
 +++ b/isort.cfg
 @@ -1,3 +0,0 @@
@@ -105,7 +105,7 @@ $ ick --rules-repo=https://github.com/advice-animal/ick-tutorial-rules-1 run --p
 +line_length = "88"
 +multi_line_output = "3"
 ```
-<!-- [[[end]]] (sum: pRsyXPoNgU)  -->
+<!-- [[[end]]] (sum: NSXvn3onvy)  -->
 
 [WHAT ELSE SHOULD GO HERE?]
 

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -168,6 +168,10 @@ class GenericPreparedStep(Step):
                 # Well then...
                 changes.append(Modified(rule_name=self.qualname, filename=k, new_bytes=self.output_state[k].value))
 
+        if self.rule_status and changes:
+            # As documented in ick_protocol, it's a fail if there are changes...
+            self.rule_status = False
+
         changes.append(
             Finished(self.qualname, status=self.rule_status, message="".join(self.messages)),
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -56,3 +56,7 @@ fail_under = 67
 precision = 1
 show_missing = True
 skip_covered = True
+
+[coverage:html]
+show_contexts = True
+skip_covered = False

--- a/tests/test_rules_shell.py
+++ b/tests/test_rules_shell.py
@@ -1,112 +1,37 @@
-import subprocess
 from pathlib import Path
 
 import pytest
 
 from ick.config import RuleConfig
 from ick.rules.shell import Rule
-from ick_protocol import Finished, Modified
+from ick.types_project import Project
 
+
+class FakeRun:
+    def __init__(self):
+        self.steps = []
+    def add_step(self, step):
+        self.steps.append(step)
 
 @pytest.mark.parametrize(
     "cmd",
     [
-        # `sed -i` works differently on Mac vs Linux, so use perl instead.
-        "perl -pi -e 's/hello/HELLO/g'",
-        ["perl", "-pi", "-e", "s/hello/HELLO/g"],
+        "sed-like -e 's/hello/HELLO/g'",
+        ["sed-like", "-e", "s/hello/HELLO/g"],
     ],
 )
 def test_smoke_single_file(cmd: str | list[str], tmp_path: Path) -> None:
-    # This duplicates stuff that ick.runner does
-    subprocess.check_call(["git", "init"], cwd=tmp_path)
-    (tmp_path / "README.md").write_text("hello world\n")
-    subprocess.check_call(["git", "add", "-N", "."], cwd=tmp_path)
-    subprocess.check_call(["git", "commit", "-a", "-m", "temp"], cwd=tmp_path)
-
     conf = RuleConfig(
         name="hello",
         impl="shell",
         command=cmd,
+        inputs=["*.md"],
     )
     rule = Rule(conf)
-    with rule.work_on_project(tmp_path) as work:
-        resp = list(work.run("hello", ["README.md"]))
 
-    assert len(resp) == 2
-    assert isinstance(resp[0], Modified)
-    assert resp[0].filename == "README.md"
-    assert resp[0].new_bytes == b"HELLO world\n"
-    assert resp[0].diffstat == "+1-1"
+    run = FakeRun()
+    projects = [Project(None, "my_subdir", "shell", "bash.sh")]
+    rule.add_steps_to_run(projects, run)
 
-    assert isinstance(resp[1], Finished)
-
-
-def test_smoke_not_found(tmp_path: Path) -> None:
-    # This duplicates stuff that ick.runner does
-    subprocess.check_call(["git", "init"], cwd=tmp_path)
-    (tmp_path / "README.md").write_text("hello world\n")
-    subprocess.check_call(["git", "add", "-N", "."], cwd=tmp_path)
-    subprocess.check_call(["git", "commit", "-a", "-m", "temp"], cwd=tmp_path)
-
-    conf = RuleConfig(
-        name="hello",
-        impl="shell",
-        command="/bin/zzyzx",
-    )
-    rule = Rule(conf)
-    with rule.work_on_project(tmp_path) as work:
-        resp = list(work.run("hello", ["README.md"]))
-
-    assert len(resp) == 1
-    assert isinstance(resp[0], Finished)
-    assert resp[0].status is None
-    assert "xargs: /bin/zzyzx: No such file or directory" in resp[0].message
-
-
-def test_smoke_failure(tmp_path: Path) -> None:
-    # This duplicates stuff that ick.runner does
-    subprocess.check_call(["git", "init"], cwd=tmp_path)
-    (tmp_path / "README.md").write_text("hello world\n")
-    subprocess.check_call(["git", "add", "-N", "."], cwd=tmp_path)
-    subprocess.check_call(["git", "commit", "-a", "-m", "temp"], cwd=tmp_path)
-
-    conf = RuleConfig(
-        name="hello",
-        impl="shell",
-        command="/bin/sh -c 'exit 1'",
-    )
-    rule = Rule(conf)
-    with rule.work_on_project(tmp_path) as work:
-        resp = list(work.run("hello", ["README.md"]))
-
-    assert len(resp) == 1
-    assert isinstance(resp[0], Finished)
-    assert resp[0].status is None
-    assert "returned non-zero exit status" in resp[0].message
-
-
-def test_smoke_repo(tmp_path: Path) -> None:
-    # This duplicates stuff that ick.runner does
-    subprocess.check_call(["git", "init"], cwd=tmp_path)
-    (tmp_path / "README.md").write_text("hello world\n")
-    subprocess.check_call(["git", "add", "-N", "."], cwd=tmp_path)
-    subprocess.check_call(["git", "commit", "-a", "-m", "temp"], cwd=tmp_path)
-
-    conf = RuleConfig(
-        name="hello",
-        impl="shell",
-        scope="repo",  # type: ignore[arg-type] # FIX ME
-        # `sed -i` works differently on Mac vs Linux, so use perl instead.
-        command="perl -pi -e 's/hello/HELLO/g' README.md",
-    )
-    rule = Rule(conf)
-    with rule.work_on_project(tmp_path) as work:
-        resp = list(work.run("hello", ["README.md"]))
-
-    assert len(resp) == 2
-    assert isinstance(resp[0], Modified)
-    assert resp[0].filename == "README.md"
-    assert resp[0].new_bytes == b"HELLO world\n"
-    assert resp[0].diffstat == "+1-1"
-
-    assert isinstance(resp[1], Finished)
+    assert len(run.steps) == 1
+    assert run.steps[0].cmdline == ["sed-like", "-e", "s/hello/HELLO/g"]


### PR DESCRIPTION
Maybe this feels too minimal?  It's checking the logic in shell.py, which doesn't do much.  The actual running of the commands is tested via scenario tests.  There's a little too much to have to create to add_steps_to_run, but it's not bad.

Also added test context tracking in the coverage report.