### PR TITLE
Add scope to add-rule

### DIFF
--- a/ick/add_rule.py
+++ b/ick/add_rule.py
@@ -17,7 +17,8 @@ def create_rule_file(rule_name: str, target_path: Path, impl: str) -> None:
                     See how to write a rule at
                     https://ick.readthedocs.io/en/latest/writing-rules/overview.html
                     """
-                    pass
+
+
                 if __name__ == "__main__":
                     main()
                 ''')
@@ -39,17 +40,13 @@ def write_rule_config_table(
     impl: str,
     inputs: Sequence[str],
     urgency: str,
+    scope: str,
     description: Optional[str] = None,
 ) -> None:
     ick_config_location = target_path / "ick.toml"
 
     # Build lines for the rule entry
-    rule_lines = [
-        "[[rule]]",
-        f'name = "{rule_name}"',
-        f'impl = "{impl}"',
-        f'urgency = "{urgency}"',
-    ]
+    rule_lines = ["[[rule]]", f'name = "{rule_name}"', f'impl = "{impl}"', f'urgency = "{urgency}"', f'scope = "{scope}"']
 
     if inputs:
         rule_lines.append(f"inputs = {json.dumps(list(inputs))}")
@@ -90,6 +87,7 @@ def add_rule_structure(
     impl: str,
     inputs: Sequence[str],
     urgency: str,
+    scope: str,
     description: Optional[str] = None,
 ) -> None:
     """
@@ -103,6 +101,7 @@ def add_rule_structure(
         impl=impl,
         inputs=inputs,
         urgency=urgency,
+        scope=scope,
         description=description,
     )
     create_test_structure(target_path=target_path, rule_name=rule_name)

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -43,7 +43,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         super().__init__(*args, **kwargs)
         self.qualname = qualname
         # TODO figure out how extra_inputs factors in
-        assert patterns is not None
+        assert patterns is not None, "File scoped rules require an `inputs` section in the rule config!"
         self.patterns = patterns
         self.match_prefix = project_path
         self.cmdline = cmdline

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -13,7 +13,7 @@ from rich import print
 from vmodule import vmodule_init
 
 from ick.add_rule import add_rule_structure
-from ick_protocol import RuleStatus, Urgency
+from ick_protocol import RuleStatus, Scope, Urgency
 
 from ._regex_translate import rule_name_re
 from .config import RuntimeConfig, Settings, load_main_config, load_rules_config, one_repo_config
@@ -118,14 +118,21 @@ def test_rules(ctx: click.Context, filters: list[str]) -> None:
     type=click.Choice(Urgency, case_sensitive=False),
     help="Urgency level for the rule",
 )
+@click.option(
+    "--scope",
+    default=Scope.FILE,
+    type=click.Choice(Scope, case_sensitive=False),
+    help="Scope of the rule",
+)
 @click.option("--description", type=str, help="Description for the rule")
 def add_rule(
     ctx: click.Context,
     rule_name: str,
     target_directory: str,
     impl: str,
-    inputs: tuple[str],
+    inputs: tuple[str, ...],
     urgency: Urgency,
+    scope: Scope,
     description: str,
 ) -> None:
     """
@@ -139,12 +146,17 @@ def add_rule(
         print("Rule structure initialization for non-python rules is not implemented yet")
         sys.exit(1)
 
+    if scope == scope.FILE and not inputs:
+        print("File-scoped rules (the default) require an `inputs` section to work!")
+        sys.exit(1)
+
     add_rule_structure(
         rule_name=rule_name,
         target_path=Path(target_directory),
         impl=impl,
         inputs=inputs,
         urgency=urgency.value,
+        scope=scope.value,
         description=description,
     )
 

--- a/tests/scenarios/add_rule/add_list_and_test_rule.txt
+++ b/tests/scenarios/add_rule/add_list_and_test_rule.txt
@@ -16,6 +16,7 @@ $ cat new_dir/ick.toml
 name = "new_rule"
 impl = "python"
 urgency = "later"
+scope = "file"
 inputs = ["*.txt", "*.md"]
 description = "Newly initialized rule"
 $ find new_dir -type f -o -type d | sort
@@ -30,7 +31,7 @@ new_dir/tests/new_rule/test1/output
 new_dir/tests/new_rule/test2
 new_dir/tests/new_rule/test2/input
 new_dir/tests/new_rule/test2/output
-$ ick add-rule another_rule new_dir --urgency now --inputs whatever
+$ ick add-rule another_rule new_dir --urgency now --inputs whatever --scope project
 Created rule config at new_dir/ick.toml
 Created dummy tests test1 and test2 with input and output in new_dir/tests/another_rule
 Created rule implementation at new_dir/another_rule.py
@@ -53,6 +54,7 @@ $ cat new_dir/ick.toml
 name = "new_rule"
 impl = "python"
 urgency = "later"
+scope = "file"
 inputs = ["*.txt", "*.md"]
 description = "Newly initialized rule"
 
@@ -60,6 +62,7 @@ description = "Newly initialized rule"
 name = "another_rule"
 impl = "python"
 urgency = "now"
+scope = "project"
 inputs = ["whatever"]
 $ find new_dir -type f -o -type d | sort
 new_dir
@@ -81,3 +84,6 @@ new_dir/tests/new_rule/test1/output
 new_dir/tests/new_rule/test2
 new_dir/tests/new_rule/test2/input
 new_dir/tests/new_rule/test2/output
+$ ick add-rule bad-rule no_inputs
+File-scoped rules (the default) require an `inputs` section to work!
+(exit status: 1)


### PR DESCRIPTION
So an ick rule like 
```
[[rule]]
name = "new_rule"
impl = "python"
urgency = "later"
```
without an `inputs` config fails with
```
assert patterns is not None, "File scoped rules require an `inputs` section in the rule config!"
```
since rules scope to File by default. I tweaked `add-rule` to match this behavior and added a `--scope` option as a way around it. Maybe that's also something we should change in the future. 