### PR TITLE
Ignore "tests" dirs when looking for rules

### DIFF
--- a/docs/writing-rules/testing.md
+++ b/docs/writing-rules/testing.md
@@ -18,6 +18,13 @@ To test your ick rules, create a `tests/` directory next to your rule file, and
 then add a directory that matches the rule name. In there, each test case should
 receive its own directory, with the directory name being the name of the test.
 
+```{note}
+Subdirectories named `tests` are reserved for test fixtures and are never
+scanned for rule definitions. This means you cannot place an `ick.toml` (or
+`pyproject.toml`) inside a `tests/` directory and expect it to register rules —
+any such file will be silently ignored by rule discovery.
+```
+
 ### Structure of a single test
 
 Each test for an ick rule consists of two directories:

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -94,9 +94,9 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
     # We use a regular glob here because it might not be from a git repo, or
     # that repo might be modified.  It also will let us more easily refer to a
     # subdir in the future.
-    potential_configs = glob("**/ick.toml", root_dir=repo_path, recursive=True)
-    potential_configs.extend(glob("**/ick.toml.local", root_dir=repo_path, recursive=True))
-    potential_configs.extend(glob("**/pyproject.toml", root_dir=repo_path, recursive=True))
+    potential_configs = [f for f in glob("**/ick.toml", root_dir=repo_path, recursive=True) if "tests" not in Path(f).parts]
+    potential_configs += [f for f in glob("**/ick.toml.local", root_dir=repo_path, recursive=True) if "tests" not in Path(f).parts]
+    potential_configs += [f for f in glob("**/pyproject.toml", root_dir=repo_path, recursive=True) if "tests" not in Path(f).parts]
     for filename in potential_configs:
         p = Path(repo_path, filename)
         LOG.log(VLOG_1, "Config found at %s", filename)

--- a/tests/fixture_rules/tests/hello/ick_toml_in_tests/input/ick.toml
+++ b/tests/fixture_rules/tests/hello/ick_toml_in_tests/input/ick.toml
@@ -1,0 +1,5 @@
+[[rule]]
+name = "should_not_be_discovered"
+impl = "shell"
+command = "true"
+scope = "repo"

--- a/tests/test_config_hook_repo.py
+++ b/tests/test_config_hook_repo.py
@@ -15,6 +15,15 @@ def test_load_rule_repo() -> None:
     rc = load_rule_repo(r)
     assert len(rc.rule) == 3
 
+
+def test_load_rule_repo_ignores_tests_dir() -> None:
+    # ick.toml files inside tests/ (e.g. rule test input fixtures) must not be
+    # treated as rule definitions.
+    r = Ruleset(base_path=Path.cwd(), path="tests/fixture_rules")
+    rc = load_rule_repo(r)
+    names = [rule.name for rule in rc.rule]
+    assert "should_not_be_discovered" not in names
+
     assert rc.rule[0].name == "hello"
     assert rc.rule[0].impl == "shell"
     assert rc.rule[0].scope == Scope.REPO


### PR DESCRIPTION
Without this change, it's basically impossible to make test fixtures for rules that alter ick rules :/