### PR TITLE
Fix --apply writing to cwd instead of --target dir; add tilde expansion

### DIFF
--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -53,7 +53,7 @@ def main(
     ctx.with_resource(keke.TraceOutput(file=trace))
 
     # This takes a target because rules can be defined in the target repo too
-    cur = Path(target)
+    cur = Path(target).expanduser()
     conf = load_main_config(cur, isolated_repo=isolated_repo)
     if rules_repo is not None:
         rules_config = one_repo_config(rules_repo)
@@ -302,7 +302,7 @@ def run(
             else:
                 assert apply
                 for mod in result.modifications:
-                    path = Path(mod.filename)
+                    path = ctx.obj.repo.root / mod.filename
                     if mod.new_bytes is None:
                         path.unlink()
                     else:

--- a/tests/scenarios/target_apply/repo/ick.toml
+++ b/tests/scenarios/target_apply/repo/ick.toml
@@ -1,0 +1,8 @@
+[[ruleset]]
+path = "."
+
+[[rule]]
+name = "write_sentinel"
+impl = "shell"
+scope = "repo"
+data = "echo changed > output.txt"

--- a/tests/scenarios/target_apply/run.txt
+++ b/tests/scenarios/target_apply/run.txt
@@ -1,0 +1,7 @@
+# Bug #157: --apply with --target should write to the target dir, not cwd.
+$ mkdir target && git -C target init -q && echo dummy > target/dummy.txt && git -C target add dummy.txt && git -C target commit -qm init >/dev/null 2>&1
+$ ick --rules-repo . --target ./target run --apply
+-> write_sentinel: NEEDS_WORK
+   Change made: output.txt                     +1
+$ cat target/output.txt
+changed


### PR DESCRIPTION
- `ctx.obj.repo.root / mod.filename` instead of `Path(mod.filename)` so that `ick run --apply --target /other/repo` writes changes into the target repo rather than the current working directory (fixes #157).
- `Path(target).expanduser()` so `--target=~/repo` expands the tilde correctly (fixes #153).
- Scenario test `target_apply` covering the --target apply path.