### PR TITLE
Add ick compare subcommand to diff results across two git refs

### DIFF
--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -261,6 +261,8 @@ def run(
     )
 
     if json_flag:
+        rule_hours: dict[str, int | None] = {impl.rule_config.qualname: impl.rule_config.hours for impl in r.iter_rule_impl()}
+
         results = collections.defaultdict(list)
         for result in r.run_steps(steps):
             modifications = []
@@ -273,6 +275,7 @@ def run(
                 # The meaning of this field depends on the status field above
                 "message": result.finished.message,
                 "metadata": result.finished.metadata,
+                "hours": rule_hours.get(result.rule),
             }
             results[result.rule].append(output)
 
@@ -332,6 +335,95 @@ main.add_command(
         help="Alias for the `run` command.",
     )
 )
+
+
+@main.command()
+@click.argument("before_ref")
+@click.argument("after_ref", default="HEAD")
+@click.option("--json", "json_flag", is_flag=True, help="Output comparison as JSON")
+@click.option("--exit-code", is_flag=True, help="Exit non-zero if any regressions found")
+@click.option("-k", "substring", default="", help="Substring match on rule name (including prefix)")
+@click.argument("filters", nargs=-1)
+@click.pass_context
+def compare(
+    ctx: click.Context,
+    before_ref: str,
+    after_ref: str,
+    json_flag: bool,
+    exit_code: bool,
+    substring: str,
+    filters: tuple[str, ...],
+) -> None:
+    """
+    Compare ick results between two git refs.
+
+    Checks out BEFORE_REF and AFTER_REF as worktrees, runs ick on each
+    against the current target, and reports improvements and regressions.
+
+    Summary metrics: rules flagging count and hours at risk (when the
+    hours field is set on rules).
+    """
+    import dataclasses
+
+    from .compare import compare_results, managed_worktree, run_ick_json, summarize
+    from .git import find_repo_root
+
+    ick_repo_root = find_repo_root(Path(__file__).parent)
+    target = Path(ctx.parent.params["target"])  # type: ignore[union-attr]
+
+    extra_args: list[str] = []
+    if substring:
+        extra_args += ["-k", substring]
+    extra_args.extend(filters)
+
+    print(f"Comparing [bold]{before_ref}[/bold]...[bold]{after_ref}[/bold] against {target}", file=sys.stderr)
+
+    print(f"  Checking out {before_ref}...", file=sys.stderr)
+    with managed_worktree(ick_repo_root, before_ref) as wt_before:
+        print(f"  Running ick at {before_ref}...", file=sys.stderr)
+        before_results = run_ick_json(wt_before, target, extra_args)
+
+    print(f"  Checking out {after_ref}...", file=sys.stderr)
+    with managed_worktree(ick_repo_root, after_ref) as wt_after:
+        print(f"  Running ick at {after_ref}...", file=sys.stderr)
+        after_results = run_ick_json(wt_after, target, extra_args)
+
+    comparisons = compare_results(before_results, after_results)
+    summary = summarize(comparisons)
+
+    if json_flag:
+        out = {
+            "before_ref": before_ref,
+            "after_ref": after_ref,
+            "comparisons": [dataclasses.asdict(c) for c in comparisons],
+            "summary": summary,
+        }
+        json.dump(out, sys.stdout, indent=4)
+        sys.stdout.write("\n")
+    else:
+        _colors = {
+            "improved": "green",
+            "regressed": "red",
+            "new": "cyan",
+            "removed": "yellow",
+            "unchanged": "dim",
+        }
+        for c in comparisons:
+            color = _colors.get(c.verdict, "")
+            h = f" ({c.hours}h)" if c.hours is not None else ""
+            print(f"[{color}]{c.verdict.upper():10}[/{color}] {c.rule}{h}: {c.detail}")
+
+        print()
+        hrs_before = f"{summary['hours_before']}h" if summary["hours_before"] is not None else "?"
+        hrs_after = f"{summary['hours_after']}h" if summary["hours_after"] is not None else "?"
+        delta = summary["rules_delta"]
+        print(f"Rules flagging: {summary['rules_flagging_before']} -> {summary['rules_flagging_after']} ({delta:+d})")
+        if summary["hours_before"] is not None:
+            h_delta = summary["hours_delta"]
+            print(f"Hours at risk:  {hrs_before} -> {hrs_after} ({h_delta:+d}h)")
+
+    if exit_code and any(c.verdict == "regressed" for c in comparisons):
+        sys.exit(1)
 
 
 def apply_filters(ctx: click.Context, filters: list[str], substring: str) -> None:

--- a/ick/compare.py
+++ b/ick/compare.py
@@ -1,0 +1,233 @@
+from __future__ import annotations
+
+import json
+import os
+import re
+import subprocess
+import sys
+from contextlib import contextmanager
+from dataclasses import dataclass
+from logging import getLogger
+from pathlib import Path
+from tempfile import TemporaryDirectory
+from typing import Any, Generator
+
+from vmodule import VLOG_1, VLOG_2
+
+LOG = getLogger(__name__)
+
+
+def parse_diff_stat(s: str | None) -> int:
+    """Convert a diffstat string like '+3-2' to total lines changed."""
+    if not s:
+        return 0
+    return sum(abs(int(x)) for x in re.findall(r"[+-]\d+", s))
+
+
+@dataclass
+class ComparisonResult:
+    rule: str
+    verdict: str  # "improved" | "regressed" | "unchanged" | "new" | "removed"
+    before_status: str | None
+    after_status: str | None
+    hours: int | None
+    detail: str
+
+
+def _entry_lines(entry: dict[str, Any]) -> int:
+    return sum(parse_diff_stat(m.get("diff_stat")) for m in entry.get("modified", []))
+
+
+def _compare_single(b: dict[str, Any], a: dict[str, Any]) -> str:
+    b_err = b["status"] == "error"
+    a_err = a["status"] == "error"
+    if b_err and not a_err:
+        return "improved"
+    if not b_err and a_err:
+        return "regressed"
+    # Neither is error from here
+    if b["status"] == "needs-work" and a["status"] == "success":
+        return "improved"
+    if b["status"] == "success" and a["status"] == "needs-work":
+        return "regressed"
+    if b["status"] == "needs-work" and a["status"] == "needs-work":
+        b_lines = _entry_lines(b)
+        a_lines = _entry_lines(a)
+        if a_lines < b_lines:
+            return "improved"
+        if a_lines > b_lines:
+            return "regressed"
+    return "unchanged"
+
+
+def _compare_rule_entries(
+    before_entries: list[dict[str, Any]],
+    after_entries: list[dict[str, Any]],
+) -> tuple[str, str, str | None, str | None]:
+    """Return (verdict, detail, before_status, after_status) for a rule."""
+    before_by_project = {e["project_name"]: e for e in before_entries}
+    after_by_project = {e["project_name"]: e for e in after_entries}
+
+    all_projects = sorted(set(before_by_project) | set(after_by_project))
+    verdicts = []
+    for proj in all_projects:
+        b = before_by_project.get(proj)
+        a = after_by_project.get(proj)
+        if b is None:
+            verdicts.append("improved")
+        elif a is None:
+            verdicts.append("regressed")
+        else:
+            verdicts.append(_compare_single(b, a))
+
+    if "regressed" in verdicts:
+        roll_up = "regressed"
+    elif "improved" in verdicts:
+        roll_up = "improved"
+    else:
+        roll_up = "unchanged"
+
+    # Build a representative detail string from the first project pair
+    first_proj = all_projects[0] if all_projects else ""
+    b0 = before_by_project.get(first_proj)
+    a0 = after_by_project.get(first_proj)
+    before_status = b0["status"] if b0 else None
+    after_status = a0["status"] if a0 else None
+
+    if before_status == "needs-work" and after_status == "needs-work":
+        b_lines = _entry_lines(b0) if b0 else 0
+        a_lines = _entry_lines(a0) if a0 else 0
+        detail = f"needs-work ({b_lines} lines) -> needs-work ({a_lines} lines)"
+    else:
+        detail = f"{before_status} -> {after_status}"
+
+    return roll_up, detail, before_status, after_status
+
+
+def compare_results(before: dict[str, Any], after: dict[str, Any]) -> list[ComparisonResult]:
+    """Compare two results dicts (from ick run --json) and return per-rule verdicts."""
+    all_rules = sorted(set(before) | set(after))
+    results = []
+
+    for rule in all_rules:
+        before_entries = before.get(rule)
+        after_entries = after.get(rule)
+
+        # Extract hours from whichever side has them
+        hours: int | None = None
+        for entries in (before_entries or [], after_entries or []):
+            for entry in entries:
+                if entry.get("hours") is not None:
+                    hours = entry["hours"]
+                    break
+            if hours is not None:
+                break
+
+        if before_entries is None:
+            after_status = after_entries[0]["status"] if after_entries else None
+            results.append(
+                ComparisonResult(
+                    rule=rule,
+                    verdict="new",
+                    before_status=None,
+                    after_status=after_status,
+                    hours=hours,
+                    detail=f"new rule (status: {after_status})",
+                )
+            )
+        elif after_entries is None:
+            before_status = before_entries[0]["status"] if before_entries else None
+            results.append(
+                ComparisonResult(
+                    rule=rule,
+                    verdict="removed",
+                    before_status=before_status,
+                    after_status=None,
+                    hours=hours,
+                    detail=f"rule removed (was: {before_status})",
+                )
+            )
+        else:
+            verdict, detail, before_status, after_status = _compare_rule_entries(before_entries, after_entries)
+            results.append(
+                ComparisonResult(
+                    rule=rule,
+                    verdict=verdict,
+                    before_status=before_status,
+                    after_status=after_status,
+                    hours=hours,
+                    detail=detail,
+                )
+            )
+
+    return results
+
+
+def summarize(comparisons: list[ComparisonResult]) -> dict[str, Any]:
+    """Compute summary metrics: rules flagging counts and hours at risk."""
+    _flagging = {"needs-work", "error"}
+
+    def _is_flagging_before(c: ComparisonResult) -> bool:
+        if c.verdict == "new":
+            return False
+        return c.before_status in _flagging
+
+    def _is_flagging_after(c: ComparisonResult) -> bool:
+        if c.verdict == "removed":
+            return False
+        return c.after_status in _flagging
+
+    rules_before = sum(1 for c in comparisons if _is_flagging_before(c))
+    rules_after = sum(1 for c in comparisons if _is_flagging_after(c))
+
+    # Only sum hours when at least one rule has hours set
+    has_hours = any(c.hours is not None for c in comparisons)
+    if has_hours:
+        hours_before: int | None = sum(c.hours or 0 for c in comparisons if _is_flagging_before(c))
+        hours_after: int | None = sum(c.hours or 0 for c in comparisons if _is_flagging_after(c))
+        hours_delta: int | None = hours_after - hours_before  # type: ignore[operator]
+    else:
+        hours_before = hours_after = hours_delta = None
+
+    return {
+        "rules_flagging_before": rules_before,
+        "rules_flagging_after": rules_after,
+        "rules_delta": rules_after - rules_before,
+        "hours_before": hours_before,
+        "hours_after": hours_after,
+        "hours_delta": hours_delta,
+    }
+
+
+def _run(cmd: list[str], *, cwd: Path | None = None, env: dict[str, str] | None = None) -> subprocess.CompletedProcess[str]:
+    LOG.log(VLOG_1, "Run %s in %s", cmd, cwd or Path.cwd())
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, cwd=cwd, check=True)
+    if result.stdout:
+        LOG.log(VLOG_2, "Stdout:\n%s", result.stdout)
+    if result.stderr:
+        LOG.log(VLOG_2, "Stderr:\n%s", result.stderr)
+    return result
+
+
+def run_ick_json(worktree_path: Path, target: Path, extra_args: list[str]) -> dict[str, Any]:
+    """Run ick from a worktree against a target directory, returning the results dict."""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = str(worktree_path)
+    cmd = [sys.executable, "-m", "ick", "--target", str(target), "run", "--json"] + extra_args
+    LOG.info("Running ick from %s against %s", worktree_path, target)
+    result = _run(cmd, env=env)
+    return json.loads(result.stdout)["results"]
+
+
+@contextmanager
+def managed_worktree(repo_root: Path, ref: str) -> Generator[Path, None, None]:
+    """Create a temporary git worktree for the given ref, cleaning up on exit."""
+    with TemporaryDirectory(prefix="ick-compare-") as td:
+        wt_path = Path(td) / "wt"
+        LOG.info("Creating worktree for %s at %s", ref, wt_path)
+        _run(["git", "worktree", "add", "--detach", str(wt_path), ref], cwd=repo_root)
+        try:
+            yield wt_path
+        finally:
+            LOG.log(VLOG_1, "Removing worktree %s", wt_path)
+            _run(["git", "worktree", "remove", "--force", str(wt_path)], cwd=repo_root)

--- a/tests/scenarios/cancelled_step/run_json.txt
+++ b/tests/scenarios/cancelled_step/run_json.txt
@@ -7,7 +7,8 @@ $ ick run --json
                 "status": "error",
                 "modified": [],
                 "message": "error: Failed to parse: `-`\n  Caused by: Expected package name starting with an alphanumeric character, found `-`\n-\n^\n",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ],
         "fix_header": [
@@ -21,7 +22,8 @@ $ ick run --json
                     }
                 ],
                 "message": "",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ]
     }

--- a/tests/scenarios/json_flag/simple.txt
+++ b/tests/scenarios/json_flag/simple.txt
@@ -7,7 +7,8 @@ $ ick run --json
                 "status": "success",
                 "modified": [],
                 "message": "did nothing, but this is a long message anyway:\nlorem ipsum quia dolor sit amet consectetur adipisci velit, sed quia non numquam eius modi tempora incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, quo voluptas nulla pariatur.\n",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ],
         "fail": [
@@ -16,7 +17,8 @@ $ ick run --json
                 "status": "error",
                 "modified": [],
                 "message": "AssertionError\n",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ],
         "move_a": [
@@ -34,7 +36,8 @@ $ ick run --json
                     }
                 ],
                 "message": "",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ],
         "testpkg/test_import": [
@@ -43,7 +46,8 @@ $ ick run --json
                 "status": "success",
                 "modified": [],
                 "message": "Hello from helper module!\n",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ]
     }

--- a/tests/scenarios/json_metadata/simple.txt
+++ b/tests/scenarios/json_metadata/simple.txt
@@ -7,7 +7,8 @@ $ ick run --json
                 "status": "success",
                 "modified": [],
                 "message": "no metadata here\n",
-                "metadata": null
+                "metadata": null,
+                "hours": null
             }
         ],
         "writes_metadata": [
@@ -29,7 +30,8 @@ $ ick run --json
                             "message": "test metadata for no_metadata.py"
                         }
                     ]
-                }
+                },
+                "hours": null
             }
         ]
     }

--- a/tests/scenarios/no_such_command/no_such_command.txt
+++ b/tests/scenarios/no_such_command/no_such_command.txt
@@ -3,6 +3,7 @@ Error: No such command 'nope'.
 
 Available commands:
   add-rule       Generate the file structure for a new rule
+  compare        Compare ick results between two git refs.
   find-projects  Lists projects found in the current repo
   list-rules     Lists rules applicable to the current repo
   run            Run the applicable rules to the current...

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -1,0 +1,235 @@
+from __future__ import annotations
+
+import pytest
+
+from ick.compare import ComparisonResult, compare_results, parse_diff_stat, summarize
+
+# ---------------------------------------------------------------------------
+# parse_diff_stat
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "s, expected",
+    [
+        (None, 0),
+        ("", 0),
+        ("+3", 3),
+        ("-5", 5),
+        ("+3-2", 5),
+        ("+10-1", 11),
+        ("+0", 0),
+    ],
+)
+def test_parse_diff_stat(s: str | None, expected: int) -> None:
+    assert parse_diff_stat(s) == expected
+
+
+# ---------------------------------------------------------------------------
+# Helpers for building fake results dicts
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    status: str,
+    *,
+    project_name: str = "",
+    diff_stat: str | None = None,
+    hours: int | None = None,
+) -> dict:
+    mods = [{"file_name": "f.py", "diff_stat": diff_stat}] if diff_stat else []
+    return {
+        "project_name": project_name,
+        "status": status,
+        "modified": mods,
+        "message": "",
+        "metadata": None,
+        "hours": hours,
+    }
+
+
+# ---------------------------------------------------------------------------
+# compare_results: verdict transitions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "before_status, after_status, expected_verdict",
+    [
+        ("success", "success", "unchanged"),
+        ("needs-work", "success", "improved"),
+        ("success", "needs-work", "regressed"),
+        ("error", "success", "improved"),
+        ("error", "needs-work", "improved"),
+        ("success", "error", "regressed"),
+        ("needs-work", "error", "regressed"),
+    ],
+)
+def test_verdict_status_transitions(before_status: str, after_status: str, expected_verdict: str) -> None:
+    before = {"rule_a": [_entry(before_status)]}
+    after = {"rule_a": [_entry(after_status)]}
+    results = compare_results(before, after)
+    assert len(results) == 1
+    assert results[0].verdict == expected_verdict
+
+
+def test_verdict_needs_work_fewer_lines_is_improved() -> None:
+    before = {"rule_a": [_entry("needs-work", diff_stat="+10")]}
+    after = {"rule_a": [_entry("needs-work", diff_stat="+3")]}
+    results = compare_results(before, after)
+    assert results[0].verdict == "improved"
+
+
+def test_verdict_needs_work_more_lines_is_regressed() -> None:
+    before = {"rule_a": [_entry("needs-work", diff_stat="+3")]}
+    after = {"rule_a": [_entry("needs-work", diff_stat="+10")]}
+    results = compare_results(before, after)
+    assert results[0].verdict == "regressed"
+
+
+def test_verdict_needs_work_same_lines_is_unchanged() -> None:
+    before = {"rule_a": [_entry("needs-work", diff_stat="+5")]}
+    after = {"rule_a": [_entry("needs-work", diff_stat="+5")]}
+    results = compare_results(before, after)
+    assert results[0].verdict == "unchanged"
+
+
+def test_verdict_new_rule() -> None:
+    before: dict = {}
+    after = {"rule_a": [_entry("needs-work")]}
+    results = compare_results(before, after)
+    assert results[0].verdict == "new"
+    assert results[0].before_status is None
+
+
+def test_verdict_removed_rule() -> None:
+    before = {"rule_a": [_entry("success")]}
+    after: dict = {}
+    results = compare_results(before, after)
+    assert results[0].verdict == "removed"
+    assert results[0].after_status is None
+
+
+def test_hours_propagated_from_after() -> None:
+    before = {"rule_a": [_entry("needs-work")]}
+    after = {"rule_a": [_entry("success", hours=4)]}
+    results = compare_results(before, after)
+    assert results[0].hours == 4
+
+
+def test_hours_propagated_from_before_when_absent_in_after() -> None:
+    before = {"rule_a": [_entry("needs-work", hours=2)]}
+    after = {"rule_a": [_entry("success", hours=None)]}
+    results = compare_results(before, after)
+    assert results[0].hours == 2
+
+
+def test_multi_rule_ordering() -> None:
+    before = {"z_rule": [_entry("needs-work")], "a_rule": [_entry("success")]}
+    after = {"z_rule": [_entry("success")], "a_rule": [_entry("needs-work")]}
+    results = compare_results(before, after)
+    assert [r.rule for r in results] == ["a_rule", "z_rule"]
+    assert results[0].verdict == "regressed"
+    assert results[1].verdict == "improved"
+
+
+def test_multi_project_any_regressed_wins() -> None:
+    before = {
+        "rule_a": [
+            _entry("needs-work", project_name="proj1"),
+            _entry("success", project_name="proj2"),
+        ]
+    }
+    after = {
+        "rule_a": [
+            _entry("success", project_name="proj1"),
+            _entry("needs-work", project_name="proj2"),
+        ]
+    }
+    results = compare_results(before, after)
+    assert results[0].verdict == "regressed"
+
+
+# ---------------------------------------------------------------------------
+# summarize
+# ---------------------------------------------------------------------------
+
+
+def _cr(verdict: str, before_status: str | None, after_status: str | None, hours: int | None = None) -> ComparisonResult:
+    return ComparisonResult(
+        rule="r",
+        verdict=verdict,
+        before_status=before_status,
+        after_status=after_status,
+        hours=hours,
+        detail="",
+    )
+
+
+def test_summarize_empty() -> None:
+    s = summarize([])
+    assert s["rules_flagging_before"] == 0
+    assert s["rules_flagging_after"] == 0
+    assert s["rules_delta"] == 0
+    assert s["hours_before"] is None
+    assert s["hours_after"] is None
+    assert s["hours_delta"] is None
+
+
+def test_summarize_counts_flagging() -> None:
+    comparisons = [
+        _cr("improved", "needs-work", "success"),
+        _cr("regressed", "success", "needs-work"),
+        _cr("unchanged", "success", "success"),
+        _cr("unchanged", "needs-work", "needs-work"),
+    ]
+    s = summarize(comparisons)
+    assert s["rules_flagging_before"] == 2  # needs-work + needs-work
+    assert s["rules_flagging_after"] == 2  # needs-work + needs-work
+    assert s["rules_delta"] == 0
+
+
+def test_summarize_new_and_removed() -> None:
+    comparisons = [
+        _cr("new", None, "needs-work"),
+        _cr("removed", "needs-work", None),
+    ]
+    s = summarize(comparisons)
+    assert s["rules_flagging_before"] == 1  # removed rule counted in before
+    assert s["rules_flagging_after"] == 1  # new rule counted in after
+    assert s["rules_delta"] == 0
+
+
+def test_summarize_hours_delta() -> None:
+    comparisons = [
+        _cr("improved", "needs-work", "success", hours=4),
+        _cr("regressed", "success", "needs-work", hours=2),
+        _cr("unchanged", "needs-work", "needs-work", hours=3),
+    ]
+    s = summarize(comparisons)
+    # before: needs-work (4h) + needs-work (3h) = 7h; after: needs-work (2h) + needs-work (3h) = 5h
+    assert s["hours_before"] == 7
+    assert s["hours_after"] == 5
+    assert s["hours_delta"] == -2
+
+
+def test_summarize_no_hours_when_all_none() -> None:
+    comparisons = [
+        _cr("regressed", "success", "needs-work", hours=None),
+    ]
+    s = summarize(comparisons)
+    assert s["hours_before"] is None
+    assert s["hours_after"] is None
+    assert s["hours_delta"] is None
+
+
+def test_summarize_partial_hours_treated_as_zero() -> None:
+    comparisons = [
+        _cr("regressed", "success", "needs-work", hours=None),
+        _cr("unchanged", "needs-work", "needs-work", hours=5),
+    ]
+    s = summarize(comparisons)
+    # has_hours=True because one entry has hours; the None entry contributes 0
+    assert s["hours_before"] == 5
+    assert s["hours_after"] == 5 + 0  # regressed: 0 before (was success), needs-work after but no hours
+    assert s["hours_delta"] == 0


### PR DESCRIPTION
- `ick compare BEFORE_REF [AFTER_REF]` checks out both refs as worktrees and runs ick against the target, reporting per-rule verdicts (improved/regressed/unchanged/new/removed)
- Summary metrics: rules flagging count and hours at risk
- `--json` for machine-readable output, `--exit-code` for CI use
- Add `hours` field to `run --json` output so consumers can compute hours deltas from a single call
- Progress messages to stderr; LOG/VLOG_1/VLOG_2 in compare.py so -v/-vv/-vvv show what's happening during long runs