### PR TITLE
Handle ignoring files and rules at project level

### DIFF
--- a/ick/_regex_translate.py
+++ b/ick/_regex_translate.py
@@ -6,8 +6,14 @@ def rule_name_re(name: str, *, legacy: bool = False) -> str:
     """
     Return a regex used with ``fullmatch`` for rule selection.
 
-    Both the new and legacy forms match a rule name plus descendants.
-    The legacy form additionally converts a ``:`` prefix separator to ``/``.
+    Rule name filters are a hybrid of path-style prefix matching and raw regex.
+    The ``name`` argument is embedded as-is (no ``re.escape``): callers are
+    responsible for escaping any metacharacters in literal names they pass in.
+    The ``($|/.*$)`` suffix anchors the match to a name *or* any descendant
+    path (e.g. ``python`` matches ``python/isort`` and ``python/black``).
+
+    The legacy form additionally rewrites a ``:`` prefix separator to ``/`` so
+    that the old ``repo/path`` naming style still matches.
     """
     if legacy:
         return f"^{name.replace(':', '/').rstrip('/')}($|/.*$)"

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -99,7 +99,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
             return False
         m = bool(match_prefix_patterns(key, self.match_prefix, self.patterns))
         if m and self.exclude_patterns:
-            filename = key[len(self.match_prefix):].lstrip("/")
+            filename = key[len(self.match_prefix) :].lstrip("/")
             m = not any(fnmatch(filename, pat) for pat in self.exclude_patterns)
         self.matches_at_least_once |= m
         return m
@@ -477,7 +477,7 @@ class BaseRule:
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
                         prefix=prefix,
-                        exclude_patterns=per_rule.exclude_filenames if per_rule else (),
+                        exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
                         batch_size=self.rule_config.batch_size,
                     )
                 )
@@ -506,7 +506,7 @@ class BaseRule:
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
                         prefix=prefix,
-                        exclude_patterns=per_rule.exclude_filenames if per_rule else (),
+                        exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
                         eager=False,
                         batch_size=-1,
                     )

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -51,7 +51,6 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         append_filenames: bool,
         rule_prepare: Callable[[], bool] | None = None,
         excluded_project_dirs: Sequence[str] = (),
-        prefix: str = "",
         exclude_patterns: Sequence[str] = (),
         *args: Any,
         **kwargs: Any,
@@ -455,7 +454,6 @@ class BaseRule:
 
     def add_steps_to_run(self, projects: Any, env: Mapping[str, str], run: Run[str, bytes | Erasure]) -> None:
         prefixed_name = self.rule_config.prefixed_name
-        prefix = self.rule_config.prefix
         name_in_repo = self.rule_config.name_in_repo
 
         if self.rule_config.scope == Scope.FILE:
@@ -476,7 +474,6 @@ class BaseRule:
                         append_filenames=True,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        prefix=prefix,
                         exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
                         batch_size=self.rule_config.batch_size,
                     )
@@ -505,7 +502,6 @@ class BaseRule:
                         append_filenames=False,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        prefix=prefix,
                         exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
                         eager=False,
                         batch_size=-1,

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -18,6 +18,7 @@ from ick_protocol import Finished, ListResponse, Modified, RuleStatus, Scope
 
 from .config import RuleConfig
 from .sh import run_cmd
+from .types_project import Project, root_project
 from .util import diffstat, merge_dicts
 
 LOG = getLogger(__name__)
@@ -452,18 +453,25 @@ class BaseRule:
         """
         return True  # no setup required
 
+    def _project_step_excludes(self, p: Project) -> Sequence[str] | None:
+        """Return the exclude patterns for p, or None if this rule should be skipped for p."""
+        name_in_repo = self.rule_config.name_in_repo
+        if self.rule_config.project_types is not None and p.typ not in self.rule_config.project_types:
+            return None
+        if name_in_repo in p.config.ignore_rules:
+            return None
+        per_rule = p.config.rules.get(name_in_repo)
+        return [*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())]
+
     def add_steps_to_run(self, projects: Any, env: Mapping[str, str], run: Run[str, bytes | Erasure]) -> None:
         prefixed_name = self.rule_config.prefixed_name
-        name_in_repo = self.rule_config.name_in_repo
 
         if self.rule_config.scope == Scope.FILE:
             for p in projects:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
-                if self.rule_config.project_types is not None and p.typ not in self.rule_config.project_types:
+                excludes = self._project_step_excludes(p)
+                if excludes is None:
                     continue
-                if name_in_repo in p.config.ignore_rules:
-                    continue
-                per_rule = p.config.rules.get(name_in_repo)
                 run.add_step(
                     GenericPreparedStep(
                         prefixed_name=prefixed_name,
@@ -474,7 +482,7 @@ class BaseRule:
                         append_filenames=True,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
+                        exclude_patterns=excludes,
                         batch_size=self.rule_config.batch_size,
                     )
                 )
@@ -485,11 +493,9 @@ class BaseRule:
             # can nest.
             for p in projects:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
-                if self.rule_config.project_types is not None and p.typ not in self.rule_config.project_types:
+                excludes = self._project_step_excludes(p)
+                if excludes is None:
                     continue
-                if name_in_repo in p.config.ignore_rules:
-                    continue
-                per_rule = p.config.rules.get(name_in_repo)
                 run.add_step(
                     GenericPreparedStep(
                         prefixed_name=prefixed_name,
@@ -502,12 +508,19 @@ class BaseRule:
                         append_filenames=False,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        exclude_patterns=[*p.config.ignore_filenames, *(per_rule.exclude_filenames if per_rule else ())],
+                        exclude_patterns=excludes,
                         eager=False,
                         batch_size=-1,
                     )
                 )
         else:  # REPO
+            root = root_project(projects)
+            if root is not None:
+                excludes = self._project_step_excludes(root)
+                if excludes is None:
+                    return
+            else:
+                excludes = ()
             run.add_step(
                 GenericPreparedStep(
                     prefixed_name=prefixed_name,
@@ -519,6 +532,7 @@ class BaseRule:
                     extra_env={**env, **self.command_env},
                     append_filenames=False,
                     rule_prepare=self.prepare,
+                    exclude_patterns=excludes,
                     eager=False,
                     batch_size=-1,
                 )

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -51,6 +51,8 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         append_filenames: bool,
         rule_prepare: Callable[[], bool] | None = None,
         excluded_project_dirs: Sequence[str] = (),
+        prefix: str = "",
+        exclude_patterns: Sequence[str] = (),
         *args: Any,
         **kwargs: Any,
     ) -> None:
@@ -59,6 +61,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         # TODO figure out how extra_inputs factors in
         assert patterns is not None, "File scoped rules require an `inputs` section in the rule config!"
         self.patterns = patterns
+        self.exclude_patterns = exclude_patterns
         self.match_prefix = project_path
         self.matches_at_least_once = False
         self.cmdline = cmdline
@@ -95,6 +98,9 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         if self._key_is_excluded(key):
             return False
         m = bool(match_prefix_patterns(key, self.match_prefix, self.patterns))
+        if m and self.exclude_patterns:
+            filename = key[len(self.match_prefix):].lstrip("/")
+            m = not any(fnmatch(filename, pat) for pat in self.exclude_patterns)
         self.matches_at_least_once |= m
         return m
 
@@ -449,10 +455,17 @@ class BaseRule:
 
     def add_steps_to_run(self, projects: Any, env: Mapping[str, str], run: Run[str, bytes | Erasure]) -> None:
         prefixed_name = self.rule_config.prefixed_name
+        prefix = self.rule_config.prefix
+        name_in_repo = self.rule_config.name_in_repo
 
         if self.rule_config.scope == Scope.FILE:
             for p in projects:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
+                if self.rule_config.project_types is not None and p.typ not in self.rule_config.project_types:
+                    continue
+                if name_in_repo in p.config.ignore_rules:
+                    continue
+                per_rule = p.config.rules.get(name_in_repo)
                 run.add_step(
                     GenericPreparedStep(
                         prefixed_name=prefixed_name,
@@ -463,6 +476,8 @@ class BaseRule:
                         append_filenames=True,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
+                        prefix=prefix,
+                        exclude_patterns=per_rule.exclude_filenames if per_rule else (),
                         batch_size=self.rule_config.batch_size,
                     )
                 )
@@ -473,6 +488,11 @@ class BaseRule:
             # can nest.
             for p in projects:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
+                if self.rule_config.project_types is not None and p.typ not in self.rule_config.project_types:
+                    continue
+                if name_in_repo in p.config.ignore_rules:
+                    continue
+                per_rule = p.config.rules.get(name_in_repo)
                 run.add_step(
                     GenericPreparedStep(
                         prefixed_name=prefixed_name,
@@ -485,6 +505,8 @@ class BaseRule:
                         append_filenames=False,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
+                        prefix=prefix,
+                        exclude_patterns=per_rule.exclude_filenames if per_rule else (),
                         eager=False,
                         batch_size=-1,
                     )

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -28,6 +28,7 @@ from .runner import HighLevelResult, Runner, _demo_done_callback, _demo_status_c
 from .types_project import maybe_repo
 
 ALLOW_LEGACY_NAME_FILTER_OPTION = "--allow-legacy-name-filter"
+REGEX_FILTER_OPTION = "--regex"
 
 
 @click.group(cls=FlexibleGroup)
@@ -84,6 +85,7 @@ def find_projects(ctx: click.Context) -> None:
 
 @main.command()
 @click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
+@click.option(REGEX_FILTER_OPTION, "regex", is_flag=True, help="Treat positional filters as raw regex instead of literal names")
 @click.option("--json", "json_flag", is_flag=True, help="Outputs json with rules info by prefixed name (can be used with run --json)")
 @click.option("-k", "substring", default="", help="Substring match on rule name")
 @click.argument("filters", nargs=-1)
@@ -91,6 +93,7 @@ def find_projects(ctx: click.Context) -> None:
 def list_rules(
     ctx: click.Context,
     allow_legacy_name_filter: bool,
+    regex: bool,
     json_flag: bool,
     substring: str,
     filters: list[str],
@@ -99,7 +102,7 @@ def list_rules(
     Lists rules applicable to the current repo
     """
     ctx.obj.filter_config.min_urgency = min(Urgency)  # List all urgencies unless specified by filters
-    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter, regex=regex)
     r = Runner(ctx.obj, ctx.obj.repo)
     if json_flag:
         r.echo_rules_json()
@@ -110,12 +113,14 @@ def list_rules(
 @main.command()
 @click.pass_context
 @click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
+@click.option(REGEX_FILTER_OPTION, "regex", is_flag=True, help="Treat positional filters as raw regex instead of literal names")
 @click.option("-k", "substring", default="", help="Substring match on rule name")
 @click.option("--update", is_flag=True, help="Update expected test output with actual rule output")
 @click.argument("filters", nargs=-1)
 def test_rules(
     ctx: click.Context,
     allow_legacy_name_filter: bool,
+    regex: bool,
     substring: str,
     update: bool,
     filters: list[str],
@@ -129,7 +134,7 @@ def test_rules(
     current rule implementation. Review the changes before committing.
     """
     ctx.obj.filter_config.min_urgency = min(Urgency)  # Test all urgencies unless specified by filters
-    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter, regex=regex)
     r = Runner(ctx.obj, ctx.obj.repo)
     sys.exit(r.test_rules(update=update))
 
@@ -215,6 +220,7 @@ def add_rule(
 @click.option("-k", "substring", default="", help="Substring match on rule name (including prefix)")
 @click.option("-q", "--question", is_flag=True, help="Exit 1 if any rule needs work, exit 2 on errors (like make -q)")
 @click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
+@click.option(REGEX_FILTER_OPTION, "regex", is_flag=True, help="Treat positional filters as raw regex instead of literal names")
 @click.argument("filters", nargs=-1)
 @click.pass_context
 def run(
@@ -228,6 +234,7 @@ def run(
     emojis: bool,
     parallelism: int,
     allow_legacy_name_filter: bool,
+    regex: bool,
     substring: str,
     question: bool,
     filters: list[str],
@@ -259,7 +266,7 @@ def run(
     else:
         ctx.obj.filter_config.min_urgency = Urgency.LATER
 
-    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter, regex=regex)
 
     # DO THE NEEDFUL
 
@@ -391,6 +398,7 @@ def apply_filters(
     substring: str,
     *,
     allow_legacy_name_filter: bool = False,
+    regex: bool = False,
 ) -> None:
     if substring and filters:
         raise click.UsageError("Cannot use -k together with positional filters")
@@ -410,8 +418,9 @@ def apply_filters(
         ctx.obj.filter_config.name_filter_re = f".*{re.escape(substring)}.*"
         ctx.obj.filter_config.legacy_name_filter_re = ctx.obj.filter_config.name_filter_re
     else:
-        ctx.obj.filter_config.name_filter_re = "|".join(rule_name_re(name) for name in filters)
-        ctx.obj.filter_config.legacy_name_filter_re = "|".join(rule_name_re(name, legacy=True) for name in filters)
+        names = filters if regex else [re.escape(name) for name in filters]
+        ctx.obj.filter_config.name_filter_re = "|".join(rule_name_re(name) for name in names)
+        ctx.obj.filter_config.legacy_name_filter_re = "|".join(rule_name_re(name, legacy=True) for name in names)
 
 
 def verbose_init(v: int, verbose: Optional[int], vmodule: Optional[str]) -> None:

--- a/ick/config/__init__.py
+++ b/ick/config/__init__.py
@@ -1,4 +1,5 @@
 from .main import MainConfig, RuntimeConfig, load_main_config
+from .project_config import PerRuleProjectConfig, ProjectConfig
 from .rules import PyprojectRulesConfig, RuleConfig, RuleRepoConfig, RulesConfig, Ruleset, load_rules_config, one_repo_config
 from .settings import FilterConfig, Settings
 
@@ -15,4 +16,6 @@ __all__ = [
     "FilterConfig",
     "Settings",
     "one_repo_config",
+    "PerRuleProjectConfig",
+    "ProjectConfig",
 ]

--- a/ick/config/project_config.py
+++ b/ick/config/project_config.py
@@ -42,6 +42,7 @@ class ProjectConfig(Struct):
 
         [tool.ick]
         ignore_rules = ["python/move_isort_cfg"]
+        ignore_filenames = ["generated/**"]  # skipped by all rules
 
         [tool.ick.rules."python/move_isort_cfg"]
         exclude_filenames = ["tests/**", "generated/**"]
@@ -49,12 +50,14 @@ class ProjectConfig(Struct):
     Example ``.ick.toml``::
 
         ignore_rules = ["python/move_isort_cfg"]
+        ignore_filenames = ["generated/**"]
 
         [rules."python/move_isort_cfg"]
         exclude_filenames = ["tests/**"]
     """
 
     ignore_rules: list[str] = field(default_factory=list)
+    ignore_filenames: list[str] = field(default_factory=list)
     rules: dict[str, PerRuleProjectConfig] = field(default_factory=dict)
 
 

--- a/ick/config/project_config.py
+++ b/ick/config/project_config.py
@@ -1,0 +1,95 @@
+"""
+Per-project configuration, read from the project directory.
+
+This is distinct from the "main" config (which controls how ick finds rules
+and projects) and from the rule-repo config (which defines rules).  This
+config lives inside a target repo and lets a project say things like
+"don't run rule X here" or "don't show rule Y the files matching Z*".
+"""
+
+from __future__ import annotations
+
+from logging import getLogger
+from pathlib import Path
+
+from msgspec import Struct, ValidationError, field
+from msgspec.toml import decode as decode_toml
+
+LOG = getLogger(__name__)
+
+
+class PerRuleProjectConfig(Struct):
+    """Per-rule overrides within a project."""
+
+    exclude_filenames: list[str] = field(default_factory=list)
+
+
+class ProjectConfig(Struct):
+    """
+    Per-project configuration loaded from the project directory.
+
+    Can be set in ``[tool.ick]`` in a ``pyproject.toml`` (Python projects)
+    or in a ``.ick.toml`` file (any project type).
+
+    Rule names are ``subdir/name`` within the rule repo — everything after the
+    prefix.  For example, if ``ick --list`` shows
+    ``advice-animal/python/move_isort_cfg``, the key to use here is
+    ``python/move_isort_cfg`` (the prefix ``advice-animal`` is omitted because
+    it is user-controlled and can vary).  For rules at the root of their repo
+    there is no subdir, so just the bare name is used.
+
+    Example ``pyproject.toml``::
+
+        [tool.ick]
+        ignore_rules = ["python/move_isort_cfg"]
+
+        [tool.ick.rules."python/move_isort_cfg"]
+        exclude_filenames = ["tests/**", "generated/**"]
+
+    Example ``.ick.toml``::
+
+        ignore_rules = ["python/move_isort_cfg"]
+
+        [rules."python/move_isort_cfg"]
+        exclude_filenames = ["tests/**"]
+    """
+
+    ignore_rules: list[str] = field(default_factory=list)
+    rules: dict[str, PerRuleProjectConfig] = field(default_factory=dict)
+
+
+class _PyprojectToolConfig(Struct):
+    ick: ProjectConfig
+
+
+class _PyprojectConfig(Struct):
+    tool: _PyprojectToolConfig
+
+
+def load_project_config(project_dir: Path) -> ProjectConfig:
+    """Load per-project ick config from a project directory.
+
+    Checks (in order):
+    - ``pyproject.toml`` → ``[tool.ick]`` section
+    - ``.ick.toml`` at the top level of the project directory
+
+    Returns an empty ``ProjectConfig`` if neither file exists or neither
+    contains an ick section.
+    """
+    pyproject = project_dir / "pyproject.toml"
+    if pyproject.exists():
+        data = pyproject.read_bytes()
+        try:
+            return decode_toml(data, type=_PyprojectConfig).tool.ick
+        except ValidationError as e:
+            msg = str(e)
+            if "Object missing required field `ick`" in msg or "Object missing required field `tool`" in msg:
+                pass  # No [tool.ick] section — fall through
+            else:
+                raise
+
+    ick_toml = project_dir / ".ick.toml"
+    if ick_toml.exists():
+        return decode_toml(ick_toml.read_bytes(), type=ProjectConfig)
+
+    return ProjectConfig()

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -117,8 +117,6 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
             rule.full_name = base + rule.name
             rule.prefixed_name = prefix + rule.full_name
             rule.name_in_repo = rule.full_name
-            rule.qualname = rule.prefixed_name
-            rule.prefix = prefix
             rule.test_path = repo_path / base / "tests" / rule.name
             rule.script_path = repo_path / base / rule.name
             rule.repo_path = repo_path

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -116,6 +116,9 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
         for rule in c.rule:
             rule.full_name = base + rule.name
             rule.prefixed_name = prefix + rule.full_name
+            rule.name_in_repo = rule.full_name
+            rule.qualname = rule.prefixed_name
+            rule.prefix = prefix
             rule.test_path = repo_path / base / "tests" / rule.name
             rule.script_path = repo_path / base / rule.name
             rule.repo_path = repo_path

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -114,9 +114,8 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
             base += "/"
         prefix = ruleset.prefix + ":" if (ruleset.prefix not in ["", "."]) else ""  # type: ignore[operator] # FIX ME
         for rule in c.rule:
-            rule.full_name = base + rule.name
-            rule.prefixed_name = prefix + rule.full_name
-            rule.name_in_repo = rule.full_name
+            rule.name_in_repo = base + rule.name
+            rule.prefixed_name = prefix + rule.name_in_repo
             rule.test_path = repo_path / base / "tests" / rule.name
             rule.script_path = repo_path / base / rule.name
             rule.repo_path = repo_path

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -106,9 +106,8 @@ class RuleConfig(Struct):
     test_path: Optional[Path] = None
     script_path: Optional[Path] = None
     repo_path: Optional[Path] = None
-    full_name: str = ""  # subdir + name, e.g. "python/move_isort_cfg" — prefix excluded
-    prefixed_name: str = ""  # user prefix + ':' + full_name, e.g. "rule:python/move_isort_cfg"
-    name_in_repo: str = ""  # alias for full_name; used for project-level ignore matching
+    name_in_repo: str = ""  # subdir + name within the rule repo, e.g. "python/move_isort_cfg"; used for project-level ignore matching
+    prefixed_name: str = ""  # user prefix + ':' + name_in_repo, e.g. "rule:python/move_isort_cfg"
 
     batch_size: int = 10
     inputs: Optional[Sequence[str]] = None
@@ -121,12 +120,10 @@ class RuleConfig(Struct):
     url: Optional[str] = None
 
     def __post_init__(self) -> None:
-        if not self.full_name:
-            self.full_name = self.name
-        if not self.prefixed_name:
-            self.prefixed_name = self.full_name
         if not self.name_in_repo:
-            self.name_in_repo = self.full_name
+            self.name_in_repo = self.name
+        if not self.prefixed_name:
+            self.prefixed_name = self.name_in_repo
 
 
 @ktrace()

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -108,8 +108,6 @@ class RuleConfig(Struct):
     repo_path: Optional[Path] = None
     full_name: str = ""  # subdir + name, e.g. "python/move_isort_cfg" — prefix excluded
     prefixed_name: str = ""  # user prefix + ':' + full_name, e.g. "rule:python/move_isort_cfg"
-    qualname: str = ""  # alias for prefixed_name; used by project-config matching code
-    prefix: str = ""  # ruleset prefix portion (e.g. "advice-animal:"), empty if none
     name_in_repo: str = ""  # alias for full_name; used for project-level ignore matching
 
     batch_size: int = 10
@@ -127,8 +125,6 @@ class RuleConfig(Struct):
             self.full_name = self.name
         if not self.prefixed_name:
             self.prefixed_name = self.full_name
-        if not self.qualname:
-            self.qualname = self.prefixed_name
         if not self.name_in_repo:
             self.name_in_repo = self.full_name
 

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -108,6 +108,9 @@ class RuleConfig(Struct):
     repo_path: Optional[Path] = None
     full_name: str = ""  # subdir + name, e.g. "python/move_isort_cfg" — prefix excluded
     prefixed_name: str = ""  # user prefix + ':' + full_name, e.g. "rule:python/move_isort_cfg"
+    qualname: str = ""  # alias for prefixed_name; used by project-config matching code
+    prefix: str = ""  # ruleset prefix portion (e.g. "advice-animal:"), empty if none
+    name_in_repo: str = ""  # alias for full_name; used for project-level ignore matching
 
     batch_size: int = 10
     inputs: Optional[Sequence[str]] = None
@@ -124,6 +127,10 @@ class RuleConfig(Struct):
             self.full_name = self.name
         if not self.prefixed_name:
             self.prefixed_name = self.full_name
+        if not self.qualname:
+            self.qualname = self.prefixed_name
+        if not self.name_in_repo:
+            self.name_in_repo = self.full_name
 
 
 @ktrace()

--- a/ick/project_finder.py
+++ b/ick/project_finder.py
@@ -8,6 +8,7 @@ from vmodule import DEFAULT_FORMAT, VLOG_1, VLOG_2
 
 from ._regex_translate import zfilename_re
 from .config import MainConfig, load_main_config
+from .config.project_config import load_project_config
 from .types_project import Project, Repo
 from .util import dir_in_dirlist, dir_in_dirlist_or_subdir
 
@@ -44,7 +45,9 @@ def find_projects(repo: Repo, zstr: str, conf: MainConfig) -> list[Project]:
         key = (dirname, typ)
         if key not in projects:
             LOG.log(VLOG_1, "Found new %r project at %r with marker %r", typ, dirname, filename)
-            projects[key] = Project(repo, dirname, typ, filename)
+            project_dir = repo.root / dirname
+            config = load_project_config(project_dir)
+            projects[key] = Project(repo, dirname, typ, filename, config)
 
     # this is a tuple to make .startswith happy
     final_project_names: tuple[str] = ()  # type: ignore[assignment] # FIX ME

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -118,7 +118,7 @@ class Runner:
                 if rule.urgency < self.rtc.filter_config.min_urgency:
                     continue
 
-                name = rule.prefixed_name.replace(":", "/") if legacy else rule.full_name
+                name = rule.prefixed_name.replace(":", "/") if legacy else rule.name_in_repo
                 if not name_filter(name):
                     continue
 

--- a/ick/types_project.py
+++ b/ick/types_project.py
@@ -5,8 +5,9 @@ from shutil import copytree
 from tempfile import TemporaryDirectory
 from typing import Callable, ContextManager, Iterable, Sequence, TypeVar
 
-from msgspec import Struct
+from msgspec import Struct, field
 
+from .config.project_config import ProjectConfig
 from .sh import run_cmd, run_cmd_status
 
 _T = TypeVar("_T")
@@ -17,6 +18,7 @@ class Project(Struct):
     subdir: str
     typ: str
     marker_filename: str
+    config: ProjectConfig = field(default_factory=ProjectConfig)
 
     def relative_filenames(self) -> Iterable[str]:
         zfiles = self.repo.zfiles

--- a/ick/types_project.py
+++ b/ick/types_project.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 from shutil import copytree
 from tempfile import TemporaryDirectory
-from typing import Callable, ContextManager, Iterable, Sequence, TypeVar
+from typing import Callable, ContextManager, Iterable, Optional, Sequence, TypeVar
 
 from msgspec import Struct, field
 
@@ -29,6 +29,27 @@ class Project(Struct):
         if self.subdir:
             filenames = [f[len(self.subdir) :] for f in filenames if f.startswith(self.subdir)]
         return filenames
+
+
+def root_project(projects: Sequence[Project]) -> Optional[Project]:
+    """
+    Return the project whose subdir is the repo root (``""``), or ``None``.
+
+    Used by REPO-scoped rules to look up a project config.  The choice of the
+    root project is somewhat arbitrary: if the repo contains multiple
+    top-level projects (e.g. a Python project at ``""`` and another at
+    ``lib/``), they all share the repo root but only the one with
+    ``subdir == ""`` is consulted.
+
+    Two draft behaviors interact here and are subject to change:
+
+    * ``skip_project_root_in_repo_root`` (main config): when set, the root
+      project is excluded from ``find_projects`` entirely, so this returns
+      ``None`` and REPO rules get no project config at all.
+    * How intermediate project configs (for nested projects) should merge with
+      the root config for the purposes of REPO-scoped rules is not yet defined.
+    """
+    return next((p for p in projects if p.subdir == ""), None)
 
 
 class BaseRepo(Struct):

--- a/tests/scenarios/run_some/list_some_rules.txt
+++ b/tests/scenarios/run_some/list_some_rules.txt
@@ -1,4 +1,4 @@
-$ ick list-rules '.*cfg'
+$ ick list-rules move_isort_cfg
 LATER
 =====
 * move_isort_cfg

--- a/tests/scenarios/run_some/run_some_rules.txt
+++ b/tests/scenarios/run_some/run_some_rules.txt
@@ -1,4 +1,4 @@
-$ ick run '.*cfg'
+$ ick run move_isort_cfg
 -> move_isort_cfg: NEEDS_WORK
      isort.cfg -3
      pyproject.toml +3

--- a/tests/scenarios/run_some/test_some_rules.txt
+++ b/tests/scenarios/run_some/test_some_rules.txt
@@ -1,3 +1,3 @@
-$ ick test-rules '.*cfg'
+$ ick test-rules move_isort_cfg
 testing...
   move_isort_cfg: .. PASS

--- a/tests/test_config_hook_repo.py
+++ b/tests/test_config_hook_repo.py
@@ -65,7 +65,7 @@ def test_load_rule_repo_ruleset_url_propagates(mocker) -> None:  # type: ignore[
     rc = load_rule_repo(r)
     for rule in rc.rule:
         assert rule.url == "https://github.com/example/rules.git"
-        assert rule.full_name
+        assert rule.name_in_repo
         assert rule.prefixed_name.startswith("rule:")
 
 

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -69,7 +69,7 @@ def test_project_finder_types() -> None:
     projects[1].repo = "FAKE"  # type: ignore[assignment]
     projects[2].repo = "FAKE"  # type: ignore[assignment]
 
-    empty_config = {"ignore_rules": [], "rules": {}}
+    empty_config = {"ignore_rules": [], "ignore_filenames": [], "rules": {}}
     assert to_builtins(projects[0]) == {
         "subdir": "a/",
         "marker_filename": "pyproject.toml",

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -69,21 +69,25 @@ def test_project_finder_types() -> None:
     projects[1].repo = "FAKE"  # type: ignore[assignment]
     projects[2].repo = "FAKE"  # type: ignore[assignment]
 
+    empty_config = {"ignore_rules": [], "rules": {}}
     assert to_builtins(projects[0]) == {
         "subdir": "a/",
         "marker_filename": "pyproject.toml",
         "typ": "python",
         "repo": "FAKE",
+        "config": empty_config,
     }
     assert to_builtins(projects[1]) == {
         "subdir": "b/",
         "marker_filename": "build.gradle",
         "typ": "java",
         "repo": "FAKE",
+        "config": empty_config,
     }
     assert to_builtins(projects[2]) == {
         "subdir": "c/",
         "marker_filename": "go.mod",
         "typ": "go",
         "repo": "FAKE",
+        "config": empty_config,
     }

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -225,7 +225,7 @@ def test_no_rules_found_mentions_legacy_flag_when_it_would_help(capsys) -> None:
     rule = RuleConfig(
         name="rule",
         impl="dummy",
-        full_name="subdir/rule",
+        name_in_repo="subdir/rule",
         prefixed_name="prefix:subdir/rule",
     )
     rtc = RuntimeConfig(main_config=MainConfig.DEFAULT, rules_config=RulesConfig(), settings=Settings())

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -112,6 +112,48 @@ def test_step_errors_when_output_hits_excluded_project_path() -> None:
     assert "excluded project path" in step.cancel_reason
 
 
+def _step_with_excludes(
+    patterns: list[str],
+    exclude_patterns: list[str] = (),
+    project_path: str = "",
+) -> GenericPreparedStep:
+    return GenericPreparedStep(
+        prefixed_name="test_rule",
+        patterns=patterns,
+        project_path=project_path,
+        cmdline=[sys.executable, "-c", "pass"],
+        extra_env={},
+        append_filenames=True,
+        exclude_patterns=exclude_patterns,
+    )
+
+
+def test_match_exclude_patterns_per_rule() -> None:
+    """Per-rule exclude_filenames prevents matched files from being processed."""
+    step = _step_with_excludes(["*.py"], exclude_patterns=["tests/**"])
+    assert step.match("foo.py") is True
+    assert step.match("tests/bar.py") is False
+
+
+def test_match_exclude_patterns_all_rules() -> None:
+    """Global ignore_filenames (merged into exclude_patterns) blocks all rules."""
+    # Simulates what add_steps_to_run does: merge global + per-rule excludes.
+    step = _step_with_excludes(["*.py"], exclude_patterns=["generated/**", "tests/special.py"])
+    assert step.match("src/main.py") is True
+    assert step.match("generated/code.py") is False
+    assert step.match("tests/special.py") is False
+    assert step.match("tests/other.py") is True  # not excluded
+
+
+def test_match_exclude_patterns_with_project_path() -> None:
+    """Excludes are relative to the project, not the repo root."""
+    step = _step_with_excludes(["*.py"], exclude_patterns=["tests/**"], project_path="packages/mylib/")
+    assert step.match("packages/mylib/src/a.py") is True
+    assert step.match("packages/mylib/tests/b.py") is False
+    # File outside the project is not matched at all (prefix doesn't match).
+    assert step.match("other/tests/c.py") is False
+
+
 def test_timeout_in_prepare_cancels_step() -> None:
     """TimeoutExpired from rule_prepare cancels the step."""
 

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -10,8 +10,8 @@ import textwrap
 from pathlib import Path
 from typing import Iterable
 
-import pytest
 import rich as _rich
+import pytest
 from click.testing import CliRunner
 
 from ick.cmdline import main

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -10,8 +10,8 @@ import textwrap
 from pathlib import Path
 from typing import Iterable
 
-import rich as _rich
 import pytest
+import rich as _rich
 from click.testing import CliRunner
 
 from ick.cmdline import main


### PR DESCRIPTION
Add per-project configs stored in the usual files, which now contain:

```
ignore_rules = [<specific rule names>]

[rules."runtime/upgrade"]
exclude_filenames = ["*_pb2.py"]
```

Should ignore just be a bool on the rule table?