### PR TITLE
Add nested project support

### DIFF
--- a/docs/concepts/projects.md
+++ b/docs/concepts/projects.md
@@ -34,7 +34,16 @@ and if the autodetection fails for you, set some of
 ```
 explicit_project_dirs = [...]
 ignore_project_dirs = [...]
+continue_project_dirs = [...]
 ```
 
 Note that explicit dirs still need to contain markers, so their type can be
 inferred.
+
+`continue_project_dirs` tells ick to keep searching for projects beneath those
+directories even if a higher-level project was already found. This is useful
+for monorepos where `services/` or `apps/` contain their own project roots.
+
+Project-scoped and file-scoped rules stop at nested project boundaries, so a
+rule for a parent project will not read or write files that belong to a child
+project.

--- a/docs/reference/config.md
+++ b/docs/reference/config.md
@@ -33,10 +33,16 @@ ick:
   explicit_project_dirs:
     - subproject1
     - subproject2
+  continue_project_dirs:
+    - services/
 ```
 
 The file can include a path into a subdirectory, and the key can be a dotted
 name to drill down through nested dictionaries in the file.
+
+`continue_project_dirs` is for nested-project layouts: it tells project
+discovery to keep looking beneath the listed directories even if a parent
+project has already been found there.
 
 ## Rulesets
 

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -428,9 +428,7 @@ class BaseRule:
 
         if self.rule_config.scope == Scope.FILE:
             for p in projects:
-                excluded_project_dirs = tuple(
-                    q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir)
-                )
+                excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
                 run.add_step(
                     GenericPreparedStep(
                         qualname=qualname,
@@ -451,9 +449,7 @@ class BaseRule:
             # project-relative paths.  There's some work to do here once they
             # can nest.
             for p in projects:
-                excluded_project_dirs = tuple(
-                    q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir)
-                )
+                excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
                 run.add_step(
                     GenericPreparedStep(
                         qualname=qualname,

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -50,6 +50,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         extra_env: dict[str, str],
         append_filenames: bool,
         rule_prepare: Callable[[], bool] | None = None,
+        excluded_project_dirs: Sequence[str] = (),
         prefix: str = "",
         *args: Any,
         **kwargs: Any,
@@ -66,6 +67,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         self.extra_env = extra_env
         self.append_filenames = append_filenames
         self.rule_prepare = rule_prepare
+        self.excluded_project_dirs = tuple(excluded_project_dirs)
         # dict key is gen, (keys, ...) and for these to match precisely we
         # should have output_state gens[self.index] == gen for all the listed
         # keys; if we have none of them then we should skip that message.
@@ -75,7 +77,25 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         self.batch_messages: dict[tuple[tuple[str, int], ...], tuple[str, int, dict[str, Any] | None]] = {}
         self.rule_status = RuleStatus.SUCCESS
 
+    def _key_is_excluded(self, key: str) -> bool:
+        for excluded_dir in self.excluded_project_dirs:
+            excluded_dir = excluded_dir.rstrip("/")
+            if key == excluded_dir or key.startswith(f"{excluded_dir}/"):
+                return True
+        return False
+
+    def _output_key(self, relative_filename: str) -> str:
+        return f"{self.match_prefix}{relative_filename}" if self.match_prefix else relative_filename
+
+    def _ensure_allowed_key(self, key: str) -> bool:
+        if self._key_is_excluded(key):
+            self.cancel(f"Produced output for excluded project path: {key!r}")
+            return False
+        return True
+
     def match(self, key: str) -> bool:
+        if self._key_is_excluded(key):
+            return False
         m = bool(match_prefix_patterns(key, self.match_prefix, self.patterns))
         self.matches_at_least_once |= m
         return m
@@ -180,24 +200,36 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
             changed, new, remv = analyze_dir(d, expected)
             # print(changed, new, remv)
 
+            outputs: list[Notification[str, bytes | Erasure]] = []
             for n in notifications:
                 relative_filename = n.key[len(self.match_prefix) :]
                 if relative_filename in changed:
-                    yield self.update_notification(n, next_gen, new_value=Path(d, relative_filename).read_bytes())
+                    key = n.key
+                    if not self._ensure_allowed_key(key):
+                        return
+                    outputs.append(self.update_notification(n, next_gen, new_value=Path(d, relative_filename).read_bytes()))
                     batch_key[n.key] = next_gen
                 elif relative_filename in remv:
-                    yield self.update_notification(n, next_gen, new_value=ERASURE)
+                    key = n.key
+                    if not self._ensure_allowed_key(key):
+                        return
+                    outputs.append(self.update_notification(n, next_gen, new_value=ERASURE))
                     batch_key[n.key] = next_gen
 
             brand_new_gens = self.update_generations((0,) * len(notifications[0].state.gens), next_gen)
             for name in new:
-                batch_key[name] = next_gen
-                yield Notification(
-                    key=name,
-                    state=State(
-                        gens=brand_new_gens,
-                        value=Path(d, name).read_bytes(),
-                    ),
+                full_key = self._output_key(name)
+                if not self._ensure_allowed_key(full_key):
+                    return
+                batch_key[full_key] = next_gen
+                outputs.append(
+                    Notification(
+                        key=full_key,
+                        state=State(
+                            gens=brand_new_gens,
+                            value=Path(d, name).read_bytes(),
+                        ),
+                    )
                 )
 
             metadata_path = Path(output_dir) / "metadata.json"
@@ -207,6 +239,8 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
 
             if batch_value:
                 self.batch_messages[tuple(batch_key.items())] = (batch_value[0], batch_value[1], batch_metadata)
+
+            yield from outputs
 
     def compute_diff_messages(self) -> list[Modified | Finished]:
         assert not self.cancelled
@@ -394,6 +428,9 @@ class BaseRule:
 
         if self.rule_config.scope == Scope.FILE:
             for p in projects:
+                excluded_project_dirs = tuple(
+                    q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir)
+                )
                 run.add_step(
                     GenericPreparedStep(
                         qualname=qualname,
@@ -403,6 +440,7 @@ class BaseRule:
                         extra_env={**env, **self.command_env},
                         append_filenames=True,
                         rule_prepare=self.prepare,
+                        excluded_project_dirs=excluded_project_dirs,
                         prefix=prefix,
                         batch_size=self.rule_config.batch_size,
                     )
@@ -413,6 +451,9 @@ class BaseRule:
             # project-relative paths.  There's some work to do here once they
             # can nest.
             for p in projects:
+                excluded_project_dirs = tuple(
+                    q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir)
+                )
                 run.add_step(
                     GenericPreparedStep(
                         qualname=qualname,
@@ -424,6 +465,7 @@ class BaseRule:
                         extra_env={**env, **self.command_env},
                         append_filenames=False,
                         rule_prepare=self.prepare,
+                        excluded_project_dirs=excluded_project_dirs,
                         prefix=prefix,
                         eager=False,
                         batch_size=-1,

--- a/ick/config/main.py
+++ b/ick/config/main.py
@@ -73,6 +73,7 @@ class MainConfig(Struct):
     # Intended to be set in a "repo" config
     explicit_project_dirs: Optional[list] = None  # type: ignore[type-arg] # FIX ME
     ignore_project_dirs: Optional[list] = None  # type: ignore[type-arg] # FIX ME
+    outer_project_dirs: Optional[list] = None  # type: ignore[type-arg] # FIX ME
 
     # A file name and key used to read additional per-repo settings. Typically
     # set in user settings.
@@ -95,6 +96,9 @@ class MainConfig(Struct):
         self.ignore_project_dirs = (
             self.ignore_project_dirs if self.ignore_project_dirs is not None else less_specific_defaults.ignore_project_dirs
         )
+        self.outer_project_dirs = (
+            self.outer_project_dirs if self.outer_project_dirs is not None else less_specific_defaults.outer_project_dirs
+        )
         self.repo_settings = self.repo_settings if self.repo_settings is not None else less_specific_defaults.repo_settings
 
 
@@ -102,6 +106,7 @@ MainConfig.DEFAULT = MainConfig(  # type: ignore[attr-defined] # FIX ME
     project_root_markers=DEFAULT_PROJECT_MARKERS,
     explicit_project_dirs=False,  # type: ignore[arg-type] # FIX ME
     skip_project_root_in_repo_root=False,
+    outer_project_dirs=False,  # type: ignore[arg-type] # FIX ME
 )
 
 

--- a/ick/project_finder.py
+++ b/ick/project_finder.py
@@ -8,17 +8,10 @@ from vmodule import DEFAULT_FORMAT, VLOG_1, VLOG_2
 
 from ._regex_translate import zfilename_re
 from .config import MainConfig, load_main_config
+from .util import dir_in_dirlist, dir_in_dirlist_or_subdir
 from .types_project import Project, Repo
 
 LOG = getLogger(__name__)
-
-
-def dir_in_dirlist(d: str, dlist: list[str]) -> bool:
-    """Is directory `d` in `dlist`? Normalizes trailing slashes."""
-    for dd in dlist:
-        if d.rstrip("/") == dd.rstrip("/"):
-            return True
-    return False
 
 
 def find_projects(repo: Repo, zstr: str, conf: MainConfig) -> list[Project]:
@@ -59,13 +52,16 @@ def find_projects(repo: Repo, zstr: str, conf: MainConfig) -> list[Project]:
 
     for project in sorted(projects.values(), key=lambda p: (p.subdir.count("/"), p.subdir)):
         if project.subdir.startswith(final_project_names) and project.subdir not in final_project_names:
-            LOG.log(
-                VLOG_1,
-                "Skipping project at %r with marker %r because it is subordinate",
-                project.subdir,
-                project.marker_filename,
-            )
-            continue
+            if conf.outer_project_dirs and dir_in_dirlist_or_subdir(project.subdir, conf.outer_project_dirs):
+                LOG.log(VLOG_1, "Keeping nested project at %r because it is in outer_project_dirs", project.subdir)
+            else:
+                LOG.log(
+                    VLOG_1,
+                    "Skipping project at %r with marker %r because it is subordinate",
+                    project.subdir,
+                    project.marker_filename,
+                )
+                continue
         else:
             LOG.debug("Keeping project at %r", project.subdir)
         final_projects.append(project)

--- a/ick/project_finder.py
+++ b/ick/project_finder.py
@@ -51,7 +51,9 @@ def find_projects(repo: Repo, zstr: str, conf: MainConfig) -> list[Project]:
     final_projects: list[Project] = []
 
     for project in sorted(projects.values(), key=lambda p: (p.subdir.count("/"), p.subdir)):
-        if project.subdir.startswith(final_project_names) and project.subdir not in final_project_names:
+        if conf.explicit_project_dirs:
+            LOG.debug("Keeping project at %r because it is in explicit_project_dirs", project.subdir)
+        elif project.subdir.startswith(final_project_names) and project.subdir not in final_project_names:
             if conf.outer_project_dirs and dir_in_dirlist_or_subdir(project.subdir, conf.outer_project_dirs):
                 LOG.log(VLOG_1, "Keeping nested project at %r because it is in outer_project_dirs", project.subdir)
             else:

--- a/ick/project_finder.py
+++ b/ick/project_finder.py
@@ -8,8 +8,8 @@ from vmodule import DEFAULT_FORMAT, VLOG_1, VLOG_2
 
 from ._regex_translate import zfilename_re
 from .config import MainConfig, load_main_config
-from .util import dir_in_dirlist, dir_in_dirlist_or_subdir
 from .types_project import Project, Repo
+from .util import dir_in_dirlist, dir_in_dirlist_or_subdir
 
 LOG = getLogger(__name__)
 

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -51,7 +51,7 @@ class HighLevelResult:
 def fmt_qualname(qualname: str, prefix: str) -> str:
     """Return Rich markup for a qualname with the prefix portion dimmed."""
     if prefix:
-        return f"[dim]{prefix}[/dim]{qualname[len(prefix):]}"
+        return f"[dim]{prefix}[/dim]{qualname[len(prefix) :]}"
     return qualname
 
 

--- a/ick/util.py
+++ b/ick/util.py
@@ -27,6 +27,24 @@ def bucket(items, key):  # type: ignore[no-untyped-def] # FIX ME
     return d
 
 
+def dir_in_dirlist(d: str, dlist: Sequence[str]) -> bool:
+    """Is directory `d` exactly in `dlist`? Normalizes trailing slashes."""
+    for dd in dlist:
+        if d.rstrip("/") == dd.rstrip("/"):
+            return True
+    return False
+
+
+def dir_in_dirlist_or_subdir(d: str, dlist: Sequence[str]) -> bool:
+    """Is directory `d` in `dlist` or inside one of its entries?"""
+    d = d.rstrip("/")
+    for dd in dlist:
+        dd = dd.rstrip("/")
+        if d == dd or d.startswith(f"{dd}/"):
+            return True
+    return False
+
+
 def merge_dicts(d1: dict | None, d2: dict | None) -> dict | None:
     if not d1:
         return d2

--- a/tests/test_config_main.py
+++ b/tests/test_config_main.py
@@ -49,11 +49,14 @@ def test_load_repo_settings_values_loaded(tmp_path: Path) -> None:
               explicit_project_dirs:
                 - services/
                 - tools/
+              outer_project_dirs:
+                - services/
         """)
     )
     result = _load_repo_settings(tmp_path, RepoSettings(file="settings.yaml", key="ick"))
     assert result is not None
     assert result.explicit_project_dirs == ["services/", "tools/"]
+    assert result.outer_project_dirs == ["services/"]
 
 
 def test_load_repo_settings_from_default_file(tmp_path: Path) -> None:

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -39,6 +39,13 @@ def test_project_finder_explicit_dirs() -> None:
     assert [p.subdir for p in find_projects(Repo(Path()), sample_string, explicit_config)] == ["a/", "c/"]
 
 
+def test_project_finder_explicit_dirs_keep_nested_projects() -> None:
+    sample_string = "services/pyproject.toml\0services/api/pyproject.toml\0services/api/tests/pyproject.toml\0"
+    explicit_config = replace(MainConfig.DEFAULT, explicit_project_dirs=["services/", "services/api/"])  # type: ignore[attr-defined] # FIX ME
+
+    assert [p.subdir for p in find_projects(Repo(Path()), sample_string, explicit_config)] == ["services/", "services/api/"]
+
+
 def test_project_finder_continue_dirs() -> None:
     sample_string = "pyproject.toml\0services/pyproject.toml\0services/api/pyproject.toml\0tools/pyproject.toml\0"
     nested_config = replace(MainConfig.DEFAULT, outer_project_dirs=["services/"])  # type: ignore[attr-defined] # FIX ME

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -39,6 +39,13 @@ def test_project_finder_explicit_dirs() -> None:
     assert [p.subdir for p in find_projects(Repo(Path()), sample_string, explicit_config)] == ["a/", "c/"]
 
 
+def test_project_finder_continue_dirs() -> None:
+    sample_string = "pyproject.toml\0services/pyproject.toml\0services/api/pyproject.toml\0tools/pyproject.toml\0"
+    nested_config = replace(MainConfig.DEFAULT, outer_project_dirs=["services/"])  # type: ignore[attr-defined] # FIX ME
+
+    assert [p.subdir for p in find_projects(Repo(Path()), sample_string, nested_config)] == ["", "services/", "services/api/"]
+
+
 def test_project_finder_marker_can_have_slashes() -> None:
     custom_config = replace(MainConfig.DEFAULT, project_root_markers={"shell": ["scripts/make.sh"]})  # type: ignore[attr-defined] # FIX ME
 

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -23,6 +23,45 @@ def _step(patterns: list[str], rule_prepare=None) -> GenericPreparedStep:
     )
 
 
+def test_step_match_excludes_nested_project_paths() -> None:
+    step = GenericPreparedStep(
+        qualname="test_rule",
+        patterns=["*.py"],
+        project_path="",
+        cmdline=[sys.executable, "-c", "pass"],
+        extra_env={},
+        append_filenames=True,
+        excluded_project_dirs=["nested/"],
+    )
+
+    assert step.match("other/file.py")
+    assert not step.match("nested/file.py")
+
+
+def test_step_errors_when_output_hits_excluded_project_path() -> None:
+    step = GenericPreparedStep(
+        qualname="test_rule",
+        patterns=["*.py"],
+        project_path="",
+        cmdline=[
+            sys.executable,
+            "-c",
+            "from pathlib import Path; Path('nested').mkdir(); Path('nested/file.py').write_text('new\\n')",
+        ],
+        extra_env={},
+        append_filenames=False,
+        excluded_project_dirs=["nested/"],
+    )
+    step.index = 0
+    step.notify(Notification(key="root.py", state=State(gens=(0,), value=b"hello")))
+
+    result = list(step.process(1, [Notification(key="root.py", state=State(gens=(0,), value=b"hello"))]))
+
+    assert result == []
+    assert step.cancelled
+    assert "excluded project path" in step.cancel_reason
+
+
 def test_timeout_in_prepare_cancels_step() -> None:
     """TimeoutExpired from rule_prepare cancels the step."""
 


### PR DESCRIPTION
This allows projects to be contained within other projects, such than
each file only belongs to the innermost one.  This is still not on by
default, and requires repo-level configuration to enable, such as:

```
[tool.ick]
outer_project_dirs = [""]
```

which would mean "root is a project, but there are probably some inside
it too."