### PR TITLE
Enable pytest-xdist

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,9 @@ mypy:
 
 .PHONY: test
 test:
-	pytest --cov=ick --cov=tests --cov-report=term-missing --cov-report=html --cov-branch --cov-context=test
+	coverage run -m pytest
+	coverage combine
+	coverage report
 
 .PHONY: clean
 clean:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,7 @@
 [tool.pytest.ini_options]
+# Many tests are network/io-bound; larger numbers don't make the run faster
+# (and in fact, auto makes it slower than 4-ish)
+addopts = "-q -n 5"
 # Don't accidentally find *_test.py files in the scenarios
 testpaths = ["tests"]
 norecursedirs = ["tests/scenarios"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -48,9 +48,10 @@ docs =
     furo
 
 test =
-    pytest-cov == 7.*
+    coverage
     pytest-mock
     pytest == 8.*
+    pytest-xdist
 
 [options.entry_points]
 console_scripts =


### PR DESCRIPTION
The test suite has gotten just slow enough for me to context-switch
while it runs -- I looked at marking some of the tests excluded for
quick runs, but most of the time is in scenarios.  Just run them in
parallel.