### PR TITLE
Deflake the json metadata test

### DIFF
--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -276,7 +276,7 @@ def run(
             }
             results[result.rule].append(output)
 
-        json.dump({"results": results}, sys.stdout, indent=4)
+        json.dump({"results": results}, sys.stdout, indent=4, sort_keys=True)
         sys.stdout.write("\n")
 
     else:

--- a/tests/scenarios/cancelled_step/run_json.txt
+++ b/tests/scenarios/cancelled_step/run_json.txt
@@ -3,25 +3,25 @@ $ ick run --json
     "results": {
         "bad_deps": [
             {
-                "project_name": "",
-                "status": "error",
-                "modified": [],
                 "message": "error: Failed to parse: `-`\n  Caused by: Expected package name starting with an alphanumeric character, found `-`\n-\n^\n",
-                "metadata": null
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "error"
             }
         ],
         "fix_header": [
             {
-                "project_name": "",
-                "status": "needs-work",
+                "message": "",
+                "metadata": null,
                 "modified": [
                     {
-                        "file_name": "pyproject.toml",
-                        "diff_stat": "+1"
+                        "diff_stat": "+1",
+                        "file_name": "pyproject.toml"
                     }
                 ],
-                "message": "",
-                "metadata": null
+                "project_name": "",
+                "status": "needs-work"
             }
         ]
     }

--- a/tests/scenarios/json_flag/simple.txt
+++ b/tests/scenarios/json_flag/simple.txt
@@ -3,47 +3,47 @@ $ ick run --json
     "results": {
         "do_nothing": [
             {
-                "project_name": "",
-                "status": "success",
-                "modified": [],
                 "message": "did nothing, but this is a long message anyway:\nlorem ipsum quia dolor sit amet consectetur adipisci velit, sed quia non numquam eius modi tempora incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, quo voluptas nulla pariatur.\n",
-                "metadata": null
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "success"
             }
         ],
         "fail": [
             {
-                "project_name": "",
-                "status": "error",
-                "modified": [],
                 "message": "AssertionError\n",
-                "metadata": null
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "error"
             }
         ],
         "move_a": [
             {
-                "project_name": "",
-                "status": "needs-work",
+                "message": "",
+                "metadata": null,
                 "modified": [
                     {
-                        "file_name": "file_a.cfg",
-                        "diff_stat": "-3"
+                        "diff_stat": "-3",
+                        "file_name": "file_a.cfg"
                     },
                     {
-                        "file_name": "file_b.toml",
-                        "diff_stat": "+3"
+                        "diff_stat": "+3",
+                        "file_name": "file_b.toml"
                     }
                 ],
-                "message": "",
-                "metadata": null
+                "project_name": "",
+                "status": "needs-work"
             }
         ],
         "testpkg/test_import": [
             {
-                "project_name": "",
-                "status": "success",
-                "modified": [],
                 "message": "Hello from helper module!\n",
-                "metadata": null
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "success"
             }
         ]
     }

--- a/tests/scenarios/json_metadata/repo/writes_metadata.py
+++ b/tests/scenarios/json_metadata/repo/writes_metadata.py
@@ -3,9 +3,9 @@ import os
 import sys
 
 output_dir = os.environ["ICK_OUTPUT_DIR"]
-findings = []
+findings = {}
 for filename in sys.argv[1:]:
-    findings.append({"file": filename, "line": 1, "message": f"test metadata for {filename}"})
+    findings[filename] = {"line": 1, "message": f"test metadata for {filename}"}
 
 with open(os.path.join(output_dir, "metadata.json"), "w") as f:
     json.dump({"findings": findings}, f)

--- a/tests/scenarios/json_metadata/simple.txt
+++ b/tests/scenarios/json_metadata/simple.txt
@@ -3,33 +3,31 @@ $ ick run --json
     "results": {
         "no_metadata": [
             {
-                "project_name": "",
-                "status": "success",
-                "modified": [],
                 "message": "no metadata here\n",
-                "metadata": null
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "success"
             }
         ],
         "writes_metadata": [
             {
-                "project_name": "",
-                "status": "needs-work",
-                "modified": [],
                 "message": "",
                 "metadata": {
-                    "findings": [
-                        {
-                            "file": "writes_metadata.py",
-                            "line": 1,
-                            "message": "test metadata for writes_metadata.py"
-                        },
-                        {
-                            "file": "no_metadata.py",
+                    "findings": {
+                        "no_metadata.py": {
                             "line": 1,
                             "message": "test metadata for no_metadata.py"
+                        },
+                        "writes_metadata.py": {
+                            "line": 1,
+                            "message": "test metadata for writes_metadata.py"
                         }
-                    ]
-                }
+                    }
+                },
+                "modified": [],
+                "project_name": "",
+                "status": "needs-work"
             }
         ]
     }


### PR DESCRIPTION
Lists are output in json in any order; dicts can be sorted.  This was
the cause of occasional test failures, but mostly worked before.