### PR TITLE
If explicit_project_dirs are provided, they all stay

### DIFF
--- a/ick/project_finder.py
+++ b/ick/project_finder.py
@@ -59,13 +59,16 @@ def find_projects(repo: Repo, zstr: str, conf: MainConfig) -> list[Project]:
 
     for project in sorted(projects.values(), key=lambda p: (p.subdir.count("/"), p.subdir)):
         if project.subdir.startswith(final_project_names) and project.subdir not in final_project_names:
-            LOG.log(
-                VLOG_1,
-                "Skipping project at %r with marker %r because it is subordinate",
-                project.subdir,
-                project.marker_filename,
-            )
-            continue
+            if conf.explicit_project_dirs:
+                LOG.debug("Keeping project at %r because it is in explicit_project_dirs", project.subdir)
+            else:
+                LOG.log(
+                    VLOG_1,
+                    "Skipping project at %r with marker %r because it is subordinate",
+                    project.subdir,
+                    project.marker_filename,
+                )
+                continue
         else:
             LOG.debug("Keeping project at %r", project.subdir)
         final_projects.append(project)

--- a/tests/test_project_finder.py
+++ b/tests/test_project_finder.py
@@ -39,6 +39,13 @@ def test_project_finder_explicit_dirs() -> None:
     assert [p.subdir for p in find_projects(Repo(Path()), sample_string, explicit_config)] == ["a/", "c/"]
 
 
+def test_project_finder_explicit_dirs_keep_nested_projects() -> None:
+    sample_string = "services/pyproject.toml\0services/api/pyproject.toml\0services/api/tests/pyproject.toml\0"
+    explicit_config = replace(MainConfig.DEFAULT, explicit_project_dirs=["services/", "services/api/"])  # type: ignore[attr-defined] # FIX ME
+
+    assert [p.subdir for p in find_projects(Repo(Path()), sample_string, explicit_config)] == ["services/", "services/api/"]
+
+
 def test_project_finder_marker_can_have_slashes() -> None:
     custom_config = replace(MainConfig.DEFAULT, project_root_markers={"shell": ["scripts/make.sh"]})  # type: ignore[attr-defined] # FIX ME
 


### PR DESCRIPTION
...during the subordinate project check.  If you've manually specified
them, we'll trust you.