### PR TITLE
Change to prefix:path/to/rule styling

### DIFF
--- a/ick/_regex_translate.py
+++ b/ick/_regex_translate.py
@@ -2,12 +2,16 @@ import re
 from typing import Iterable
 
 
-def rule_name_re(prefix: str) -> str:
+def rule_name_re(name: str, *, legacy: bool = False) -> str:
     """
-    Returns a regular expression string that matches either prefix/ or prefix
-    as the entire string.  The regex is used with re.fullmatch.
+    Return a regex used with ``fullmatch`` for rule selection.
+
+    Both the new and legacy forms match a rule name plus descendants.
+    The legacy form additionally converts a ``:`` prefix separator to ``/``.
     """
-    return f"^{prefix.rstrip('/')}($|/.*$)"
+    if legacy:
+        return f"^{name.replace(':', '/').rstrip('/')}($|/.*$)"
+    return f"^{name.rstrip('/')}($|/.*$)"
 
 
 def zfilename_re(opts: Iterable[str]) -> re.Pattern[str]:

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -43,7 +43,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
 
     def __init__(
         self,
-        qualname: str,
+        prefixed_name: str,
         patterns: Sequence[str],
         project_path: str,
         cmdline: Sequence[str | Path],
@@ -51,13 +51,11 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
         append_filenames: bool,
         rule_prepare: Callable[[], bool] | None = None,
         excluded_project_dirs: Sequence[str] = (),
-        prefix: str = "",
         *args: Any,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.qualname = qualname
-        self.prefix = prefix
+        self.prefixed_name = prefixed_name
         # TODO figure out how extra_inputs factors in
         assert patterns is not None, "File scoped rules require an `inputs` section in the rule config!"
         self.patterns = patterns
@@ -138,7 +136,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
     def _gravitational_constant(self) -> int:
         return 1
 
-    @ktrace("self.qualname", "self.match_prefix", "next_gen")
+    @ktrace("self.prefixed_name", "self.match_prefix", "next_gen")
     def process(
         self,
         next_gen: int,
@@ -282,7 +280,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
 
                 changes.append(
                     Modified(
-                        rule_name=self.qualname,
+                        rule_name=self.prefixed_name,
                         filename=k,
                         new_bytes=None if b is ERASURE else b,
                         diff=diff,
@@ -301,7 +299,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
                     diff_stat = None
                 changes.append(
                     Modified(
-                        rule_name=self.qualname,
+                        rule_name=self.prefixed_name,
                         filename=k,
                         new_bytes=new_bytes,
                         diff=diff,
@@ -347,7 +345,7 @@ class GenericPreparedStep(Step[str, bytes | Erasure]):
             self.rule_status = RuleStatus.NEEDS_WORK
 
         changes.append(
-            Finished(self.qualname, status=self.rule_status, message="".join(msgs), metadata=metadata),
+            Finished(self.prefixed_name, status=self.rule_status, message="".join(msgs), metadata=metadata),
         )
         return changes
 
@@ -450,15 +448,14 @@ class BaseRule:
         return True  # no setup required
 
     def add_steps_to_run(self, projects: Any, env: Mapping[str, str], run: Run[str, bytes | Erasure]) -> None:
-        qualname = self.rule_config.qualname
-        prefix = self.rule_config.prefix
+        prefixed_name = self.rule_config.prefixed_name
 
         if self.rule_config.scope == Scope.FILE:
             for p in projects:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
                 run.add_step(
                     GenericPreparedStep(
-                        qualname=qualname,
+                        prefixed_name=prefixed_name,
                         patterns=self.rule_config.inputs,  # Don't default, let it raise
                         project_path=p.subdir,
                         cmdline=self.command_parts,
@@ -466,7 +463,6 @@ class BaseRule:
                         append_filenames=True,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        prefix=prefix,
                         batch_size=self.rule_config.batch_size,
                     )
                 )
@@ -479,7 +475,7 @@ class BaseRule:
                 excluded_project_dirs = tuple(q.subdir for q in projects if q.subdir != p.subdir and q.subdir.startswith(p.subdir))
                 run.add_step(
                     GenericPreparedStep(
-                        qualname=qualname,
+                        prefixed_name=prefixed_name,
                         # Default to wanting all files, but allow specifying that
                         # you want _no_ files as empty list.
                         patterns=("*",) if self.rule_config.inputs is None else self.rule_config.inputs,
@@ -489,7 +485,6 @@ class BaseRule:
                         append_filenames=False,
                         rule_prepare=self.prepare,
                         excluded_project_dirs=excluded_project_dirs,
-                        prefix=prefix,
                         eager=False,
                         batch_size=-1,
                     )
@@ -497,7 +492,7 @@ class BaseRule:
         else:  # REPO
             run.add_step(
                 GenericPreparedStep(
-                    qualname=qualname,
+                    prefixed_name=prefixed_name,
                     # Default to wanting all files, but allow specifying that
                     # you want _no_ files as empty list.
                     patterns=("*",) if self.rule_config.inputs is None else self.rule_config.inputs,
@@ -506,7 +501,6 @@ class BaseRule:
                     extra_env={**env, **self.command_env},
                     append_filenames=False,
                     rule_prepare=self.prepare,
-                    prefix=prefix,
                     eager=False,
                     batch_size=-1,
                 )

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -24,8 +24,10 @@ from .click_better import FlexibleGroup
 from .config import RuntimeConfig, Settings, load_main_config, load_rules_config, one_repo_config
 from .git import find_repo_root
 from .project_finder import find_projects as find_projects_fn
-from .runner import HighLevelResult, Runner, _demo_done_callback, _demo_status_callback, fmt_qualname
+from .runner import HighLevelResult, Runner, _demo_done_callback, _demo_status_callback, fmt_name
 from .types_project import maybe_repo
+
+ALLOW_LEGACY_NAME_FILTER_OPTION = "--allow-legacy-name-filter"
 
 
 @click.group(cls=FlexibleGroup)
@@ -81,16 +83,23 @@ def find_projects(ctx: click.Context) -> None:
 
 
 @main.command()
-@click.option("--json", "json_flag", is_flag=True, help="Outputs json with rules info by qualname (can be used with run --json)")
-@click.option("-k", "substring", default="", help="Substring match on rule name (including prefix)")
+@click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
+@click.option("--json", "json_flag", is_flag=True, help="Outputs json with rules info by prefixed name (can be used with run --json)")
+@click.option("-k", "substring", default="", help="Substring match on rule name")
 @click.argument("filters", nargs=-1)
 @click.pass_context
-def list_rules(ctx: click.Context, json_flag: bool, substring: str, filters: list[str]) -> None:
+def list_rules(
+    ctx: click.Context,
+    allow_legacy_name_filter: bool,
+    json_flag: bool,
+    substring: str,
+    filters: list[str],
+) -> None:
     """
     Lists rules applicable to the current repo
     """
     ctx.obj.filter_config.min_urgency = min(Urgency)  # List all urgencies unless specified by filters
-    apply_filters(ctx, filters, substring)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
     r = Runner(ctx.obj, ctx.obj.repo)
     if json_flag:
         r.echo_rules_json()
@@ -100,10 +109,17 @@ def list_rules(ctx: click.Context, json_flag: bool, substring: str, filters: lis
 
 @main.command()
 @click.pass_context
-@click.option("-k", "substring", default="", help="Substring match on rule name (including prefix)")
+@click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
+@click.option("-k", "substring", default="", help="Substring match on rule name")
 @click.option("--update", is_flag=True, help="Update expected test output with actual rule output")
 @click.argument("filters", nargs=-1)
-def test_rules(ctx: click.Context, substring: str, update: bool, filters: list[str]) -> None:
+def test_rules(
+    ctx: click.Context,
+    allow_legacy_name_filter: bool,
+    substring: str,
+    update: bool,
+    filters: list[str],
+) -> None:
     """
     Run rule self-tests.
 
@@ -113,7 +129,7 @@ def test_rules(ctx: click.Context, substring: str, update: bool, filters: list[s
     current rule implementation. Review the changes before committing.
     """
     ctx.obj.filter_config.min_urgency = min(Urgency)  # Test all urgencies unless specified by filters
-    apply_filters(ctx, filters, substring)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
     r = Runner(ctx.obj, ctx.obj.repo)
     sys.exit(r.test_rules(update=update))
 
@@ -155,7 +171,7 @@ def add_rule(
     rule-name (TEXT): The name of the new rule\n
     target-directory (PATH): The desired directory of the new rule.
     """
-    # TODO: Check if rule qualname already exists using ctx.obj
+    # TODO: Check if rule name already exists using ctx.obj
     if impl != "python":
         print("Rule structure initialization for non-python rules is not implemented yet")
         sys.exit(1)
@@ -185,7 +201,7 @@ def add_rule(
 @click.option("-n", "--dry-run", is_flag=True, help="Dry run mode, show counts of lines to change (default)")
 @click.option("-p", "--patch", is_flag=True, help="Show patches of changes to make")
 @click.option("--apply", is_flag=True, help="Apply changes")
-@click.option("--json", "json_flag", is_flag=True, help="Outputs modifications json by rule qualname (can be used with list-rules --json)")
+@click.option("--json", "json_flag", is_flag=True, help="Outputs modifications json by prefixed rule name (can be used with list-rules --json)")
 @click.option(
     "--json-file",
     "json_file",
@@ -198,6 +214,7 @@ def add_rule(
 @click.option("--parallelism", type=int, default=0, help="Number of parallel workers (default: auto)")
 @click.option("-k", "substring", default="", help="Substring match on rule name (including prefix)")
 @click.option("-q", "--question", is_flag=True, help="Exit 1 if any rule needs work, exit 2 on errors (like make -q)")
+@click.option(ALLOW_LEGACY_NAME_FILTER_OPTION, is_flag=True, help="Allow legacy slash-joined rule-name filtering")
 @click.argument("filters", nargs=-1)
 @click.pass_context
 def run(
@@ -210,6 +227,7 @@ def run(
     skip_update: bool,
     emojis: bool,
     parallelism: int,
+    allow_legacy_name_filter: bool,
     substring: str,
     question: bool,
     filters: list[str],
@@ -241,7 +259,7 @@ def run(
     else:
         ctx.obj.filter_config.min_urgency = Urgency.LATER
 
-    apply_filters(ctx, filters, substring)
+    apply_filters(ctx, filters, substring, allow_legacy_name_filter=allow_legacy_name_filter)
 
     # DO THE NEEDFUL
 
@@ -305,7 +323,7 @@ def run(
             if json_file is not None:
                 _collect_json_result(result, json_results)
             where = f" on {result.project}" if result.project else ""
-            print(f"-> [bold]{fmt_qualname(result.rule, result.prefix)}[/bold]{where}: ", end="")
+            print(f"-> [bold]{fmt_name(result.rule)}[/bold]{where}: ", end="")
             match result.finished.status:
                 case RuleStatus.ERROR:
                     exit_code = max(exit_code, 2)
@@ -367,12 +385,19 @@ main.add_command(
 )
 
 
-def apply_filters(ctx: click.Context, filters: list[str], substring: str) -> None:
+def apply_filters(
+    ctx: click.Context,
+    filters: list[str],
+    substring: str,
+    *,
+    allow_legacy_name_filter: bool = False,
+) -> None:
     if substring and filters:
         raise click.UsageError("Cannot use -k together with positional filters")
     if substring and " " in substring:
         raise click.UsageError("-k with spaces is not yet supported")
 
+    ctx.obj.filter_config.allow_legacy_name_filter = allow_legacy_name_filter
     if not substring and not filters:
         pass
     elif len(filters) == 1 and getattr(Urgency, filters[0].upper(), None):
@@ -383,8 +408,10 @@ def apply_filters(ctx: click.Context, filters: list[str], substring: str) -> Non
         ctx.obj.filter_config.min_urgency = urgency
     elif substring:
         ctx.obj.filter_config.name_filter_re = f".*{re.escape(substring)}.*"
+        ctx.obj.filter_config.legacy_name_filter_re = ctx.obj.filter_config.name_filter_re
     else:
         ctx.obj.filter_config.name_filter_re = "|".join(rule_name_re(name) for name in filters)
+        ctx.obj.filter_config.legacy_name_filter_re = "|".join(rule_name_re(name, legacy=True) for name in filters)
 
 
 def verbose_init(v: int, verbose: Optional[int], vmodule: Optional[str]) -> None:

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -67,7 +67,7 @@ def discover_rules(rtc: RuntimeConfig) -> Sequence[RuleConfig]:
     for k, v in rulesets.items():
         rules.extend(v.rule)
 
-    rules.sort(key=lambda h: (h.order, h.qualname))
+    rules.sort(key=lambda h: (h.order, h.prefixed_name))
 
     return rules
 
@@ -112,11 +112,10 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
         base = dirname(filename).lstrip("/")
         if base:
             base += "/"
-        prefix = ruleset.prefix + "/" if (ruleset.prefix not in ["", "."]) else ""  # type: ignore[operator] # FIX ME
+        prefix = ruleset.prefix + ":" if (ruleset.prefix not in ["", "."]) else ""  # type: ignore[operator] # FIX ME
         for rule in c.rule:
             rule.full_name = base + rule.name
-            rule.qualname = prefix + rule.full_name
-            rule.prefix = prefix
+            rule.prefixed_name = prefix + rule.full_name
             rule.test_path = repo_path / base / "tests" / rule.name
             rule.script_path = repo_path / base / rule.name
             rule.repo_path = repo_path

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -106,9 +106,8 @@ class RuleConfig(Struct):
     test_path: Optional[Path] = None
     script_path: Optional[Path] = None
     repo_path: Optional[Path] = None
-    qualname: str = ""  # full display name: prefix + full_name
-    prefix: str = ""  # ruleset prefix portion (e.g. "netflix/"), empty if none
-    full_name: str = ""  # the rule name within the repo (e.g. "python/my_rule")
+    full_name: str = ""  # subdir + name, e.g. "python/move_isort_cfg" — prefix excluded
+    prefixed_name: str = ""  # user prefix + ':' + full_name, e.g. "rule:python/move_isort_cfg"
 
     batch_size: int = 10
     inputs: Optional[Sequence[str]] = None
@@ -121,8 +120,10 @@ class RuleConfig(Struct):
     url: Optional[str] = None
 
     def __post_init__(self) -> None:
-        if not self.qualname:
-            self.qualname = self.name
+        if not self.full_name:
+            self.full_name = self.name
+        if not self.prefixed_name:
+            self.prefixed_name = self.full_name
 
 
 @ktrace()

--- a/ick/config/settings.py
+++ b/ick/config/settings.py
@@ -29,6 +29,10 @@ class FilterConfig(Struct):
 
     #: Default means "don't filter any names"
     name_filter_re: str = ".*"
+    #: Legacy prefix-aware fallback, compared against slash-joined names.
+    legacy_name_filter_re: str = ".*"
+    #: If true, use the legacy prefix-aware matcher instead of the new one.
+    allow_legacy_name_filter: bool = False
     #: Default means "don't filter any production urgencies"
     min_urgency: Urgency = Urgency.LATER
     min_risk: Risk = Risk.HIGH

--- a/ick/rules/python.py
+++ b/ick/rules/python.py
@@ -46,8 +46,8 @@ class Rule(BaseRule):
         self.coverage = bool(int(os.environ.get("ICK_COVERAGE_PY", "0")))
 
         # TODO validate path / rule.name ".py" exists
-        assert rule_config.qualname != ""
-        venv_key = rule_config.qualname + ("-cov" if self.coverage else "")
+        assert rule_config.prefixed_name != ""
+        venv_key = rule_config.prefixed_name + ("-cov" if self.coverage else "")
         venv_path = Path(platformdirs.user_cache_dir("ick", "advice-animal"), "envs", venv_key)
         deps = self.rule_config.deps or []
         if self.coverage:

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -39,21 +39,21 @@ class HighLevelResult:
     """
     Capture the result of running ick in a structured way.
 
-    rule is the qualified name of the rule
+    rule is the prefixed name of the rule
     """
 
     rule: str
     project: str
     modifications: Sequence[Modified]
     finished: Finished
-    prefix: str = ""
 
 
-def fmt_qualname(qualname: str, prefix: str) -> str:
-    """Return Rich markup for a qualname with the prefix portion dimmed."""
-    if prefix:
-        return f"[dim]{prefix}[/dim]{qualname[len(prefix) :]}"
-    return qualname
+def fmt_name(name: str) -> str:
+    """Return Rich markup for a name with the prefix portion dimmed."""
+    if ":" in name:
+        prefix, suffix = name.split(":", 1)
+        return f"[dim]{prefix}:[/dim]{suffix}"
+    return name
 
 
 @dataclass
@@ -111,25 +111,42 @@ class Runner:
         self.projects: list[Project] = find_projects(repo, repo.zfiles, self.rtc.main_config)
 
     def iter_rule_impl(self) -> Iterable[BaseRule]:
-        name_filter = re.compile(self.rtc.filter_config.name_filter_re).fullmatch
-        rules_matched = 0
-        for rule in self.rules:
-            if rule.urgency < self.rtc.filter_config.min_urgency:
-                continue
+        def matched_rules(*, legacy: bool) -> list[BaseRule]:
+            filter_re = self.rtc.filter_config.legacy_name_filter_re if legacy else self.rtc.filter_config.name_filter_re
+            name_filter = re.compile(filter_re).fullmatch
+            rules: list[BaseRule] = []
+            for rule in self.rules:
+                if rule.urgency < self.rtc.filter_config.min_urgency:
+                    continue
 
-            if not name_filter(rule.qualname):
-                continue
+                name = rule.prefixed_name.replace(":", "/") if legacy else rule.full_name
+                if not name_filter(name):
+                    continue
 
-            rules_matched += 1
-            try:
-                yield get_impl(rule)(rule)
-            except Exception as e:
-                yield ErrorRule(rule, str(e))
+                try:
+                    rules.append(get_impl(rule)(rule))
+                except Exception as e:
+                    rules.append(ErrorRule(rule, str(e)))
+        return rules
 
-        if rules_matched == 0 and len(self.rules) > 0:
+        rules = matched_rules(legacy=False)
+        legacy_rules: list[BaseRule] = []
+        if not rules and self.rtc.filter_config.allow_legacy_name_filter:
+            rules = matched_rules(legacy=True)
+        elif not rules:
+            legacy_rules = matched_rules(legacy=True)
+
+        if not rules and len(self.rules) > 0:
+            pattern = self.rtc.filter_config.name_filter_re
+            hint = ""
+            if legacy_rules:
+                hint = " Try --allow-legacy-name-filter."
             print(
-                f"[red]No rules found with urgency '{self.rtc.filter_config.min_urgency.value}' or greater that matches the pattern '{self.rtc.filter_config.name_filter_re}'.[/red]"
+                f"[red]No rules found with urgency '{self.rtc.filter_config.min_urgency.value}' or greater that matches the pattern '{pattern}'.{hint}[/red]"
             )
+
+        for rule in rules:
+            yield rule
 
     def build_steps_for_rules(
         self,
@@ -203,7 +220,7 @@ class Runner:
             for rule_instance, futures in rule_futures:
                 success = True
                 any_updated = False
-                qn = fmt_qualname(rule_instance.rule_config.qualname, rule_instance.rule_config.prefix)
+                qn = fmt_name(rule_instance.rule_config.prefixed_name)
                 print(f"  [bold]{qn}[/bold]: ", end="")
                 if not futures:
                     print("<no-test>", end="")
@@ -436,13 +453,13 @@ class Runner:
                 # This should also encompass exit codes other than 0 and 99
                 # print(f"{s} failed:")
                 # print(f"  {s.cancel_reason}")
-                yield HighLevelResult(s.qualname, s.match_prefix, [], Finished(s.qualname, RuleStatus.ERROR, s.cancel_reason), s.prefix)
+                yield HighLevelResult(s.prefixed_name, s.match_prefix, [], Finished(s.prefixed_name, RuleStatus.ERROR, s.cancel_reason))
             else:
                 # if any(e == 99 for e in s.exit_codes):
                 #     ...
 
                 changes = s.compute_diff_messages()
-                yield HighLevelResult(s.qualname, s.match_prefix, changes[:-1], changes[-1], s.prefix)
+                yield HighLevelResult(s.prefixed_name, s.match_prefix, changes[:-1], changes[-1])
 
     @ktrace()
     def echo_rules(self) -> None:
@@ -450,7 +467,7 @@ class Runner:
         for impl in self.iter_rule_impl():
             impl.prepare()
 
-            msg = f"[bold]{fmt_qualname(impl.rule_config.qualname, impl.rule_config.prefix)}[/]"
+            msg = f"[bold]{fmt_name(impl.rule_config.prefixed_name)}[/]"
             if impl.rule_config.description:
                 msg += f": {impl.rule_config.description}"
             if not impl.runnable:
@@ -484,7 +501,7 @@ class Runner:
                 "contact": config.contact,
                 "url": config.url,
             }
-            rules[config.qualname] = rule
+            rules[config.prefixed_name] = rule
 
         print(json.dumps({"rules": rules}, indent=4))
 

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -79,13 +79,12 @@ class ErrorRule(BaseRule):
 
     def add_steps_to_run(self, projects: Any, env: Any, run: Run[str, bytes | Erasure]) -> None:
         step = GenericPreparedStep(
-            qualname=self.rule_config.qualname,
+            prefixed_name=self.rule_config.prefixed_name,
             patterns=("*",),
             project_path="",
             cmdline=[],
             extra_env={},
             append_filenames=False,
-            prefix=self.rule_config.prefix or "",
             eager=False,
             batch_size=-1,
         )
@@ -127,7 +126,7 @@ class Runner:
                     rules.append(get_impl(rule)(rule))
                 except Exception as e:
                     rules.append(ErrorRule(rule, str(e)))
-        return rules
+            return rules
 
         rules = matched_rules(legacy=False)
         legacy_rules: list[BaseRule] = []

--- a/tests/scenarios/json_flag_rules/simple.txt
+++ b/tests/scenarios/json_flag_rules/simple.txt
@@ -1,7 +1,7 @@
 $ ick list-rules --json
 {
     "rules": {
-        "rule/do_nothing": {
+        "rule:do_nothing": {
             "duration": null,
             "description": null,
             "urgency": "LATER",
@@ -9,7 +9,7 @@ $ ick list-rules --json
             "contact": "john",
             "url": null
         },
-        "rule/fail": {
+        "rule:fail": {
             "duration": 2,
             "description": null,
             "urgency": "LATER",
@@ -17,7 +17,7 @@ $ ick list-rules --json
             "contact": null,
             "url": "url"
         },
-        "rule/move_a": {
+        "rule:move_a": {
             "duration": null,
             "description": "Description for move_a",
             "urgency": "NOW",

--- a/tests/test_cmdline.py
+++ b/tests/test_cmdline.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from ick.cmdline import apply_filters
+from ick.config import FilterConfig
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(obj=SimpleNamespace(filter_config=FilterConfig()))
+
+
+def test_apply_filters_uses_new_matching_by_default() -> None:
+    ctx = _ctx()
+    apply_filters(ctx, ["subdir/rule"], "", allow_legacy_name_filter=False)
+
+    assert ctx.obj.filter_config.allow_legacy_name_filter is False
+    assert ctx.obj.filter_config.name_filter_re == "^subdir/rule($|/.*$)"
+    assert ctx.obj.filter_config.legacy_name_filter_re == "^subdir/rule($|/.*$)"
+
+
+def test_apply_filters_can_force_legacy_matching() -> None:
+    ctx = _ctx()
+    apply_filters(ctx, ["rule/subdir/rule"], "", allow_legacy_name_filter=True)
+
+    assert ctx.obj.filter_config.allow_legacy_name_filter is True
+    assert ctx.obj.filter_config.name_filter_re == "^rule/subdir/rule($|/.*$)"
+    assert ctx.obj.filter_config.legacy_name_filter_re == "^rule/subdir/rule($|/.*$)"
+
+
+def test_apply_filters_does_not_fallback_for_substring_search() -> None:
+    ctx = _ctx()
+    apply_filters(ctx, [], "needle", allow_legacy_name_filter=False)
+
+    assert ctx.obj.filter_config.allow_legacy_name_filter is False
+    assert ctx.obj.filter_config.name_filter_re == ".*needle.*"
+    assert ctx.obj.filter_config.legacy_name_filter_re == ".*needle.*"

--- a/tests/test_config_hook_repo.py
+++ b/tests/test_config_hook_repo.py
@@ -61,10 +61,12 @@ def test_discover() -> None:
 def test_load_rule_repo_ruleset_url_propagates(mocker) -> None:  # type: ignore[no-untyped-def] # FIX ME
     fixture_path = Path("tests/fixture_rules").resolve()
     mocker.patch("ick.config.rule_repo.update_local_cache", return_value=fixture_path)
-    r = Ruleset(url="https://github.com/example/rules.git")
+    r = Ruleset(url="https://github.com/example/rules.git", prefix="rule")
     rc = load_rule_repo(r)
     for rule in rc.rule:
         assert rule.url == "https://github.com/example/rules.git"
+        assert rule.full_name
+        assert rule.prefixed_name.startswith("rule:")
 
 
 def test_ruleset_url_and_path_error() -> None:

--- a/tests/test_python_relative_imports.py
+++ b/tests/test_python_relative_imports.py
@@ -41,7 +41,7 @@ def test_python_relative_imports(tmp_path: Path) -> None:
             impl="python",
             script_path=script_path.with_suffix(""),  # without .py
             repo_path=repo_path,
-            qualname="test/main",
+            prefixed_name="test:main",
         ),
     )
 
@@ -64,7 +64,7 @@ def test_python_module_path_conversion() -> None:
             impl="python",
             script_path=script_path,
             repo_path=repo_path,
-            qualname="test/subdir/myscript",
+            prefixed_name="test:subdir/myscript",
         ),
     )
 

--- a/tests/test_regex_translate.py
+++ b/tests/test_regex_translate.py
@@ -6,20 +6,30 @@ from ick._regex_translate import rule_name_re, zfilename_re
 def test_advice_name_matching() -> None:
     foo_match = re.compile(rule_name_re("foo")).fullmatch
     assert foo_match("foo")
-    assert foo_match("foo/hello")
-    assert foo_match("foo/hello/goo")
+    assert not foo_match("prefix:foo")
+    assert foo_match("foo/bar")
+    assert foo_match("foo/bar/goo")
     assert not foo_match("food_truck")
-    assert not foo_match("py/foo")
-    assert not foo_match("py/foo/goo")
+    assert not foo_match("py:foo/bar")
+    assert not foo_match("py:foo/goo")
 
 
-def test_advice_name_matching_prefix_with_trailing_slash() -> None:
-    foo_match = re.compile(rule_name_re("foo/")).fullmatch
-    assert foo_match("foo")
-    assert foo_match("foo/hello")
-    assert foo_match("foo/hello/goo")
+def test_advice_name_matching_subdir_rule_across_prefixes() -> None:
+    foo_match = re.compile(rule_name_re("subdir/rule")).fullmatch
+    assert foo_match("subdir/rule")
+    assert not foo_match("prefix:subdir/rule")
+    assert foo_match("subdir/rule/extra")
+    assert not foo_match("prefix:subdir/rule/extra")
     assert not foo_match("food_truck")
-    assert not foo_match("py/foo")
+
+
+def test_advice_name_matching_prefix_with_legacy_join() -> None:
+    foo_match = re.compile(rule_name_re("foo:bar", legacy=True)).fullmatch
+    assert foo_match("foo/bar")
+    assert foo_match("foo/bar/hello")
+    assert foo_match("foo/bar/hello/goo")
+    assert not foo_match("bar")
+    assert not foo_match("py/bar")
 
 
 def test_regex_matching_zfilenames() -> None:

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -75,7 +75,7 @@ def test_double_star_is_not_special() -> None:
 
 def test_step_match_excludes_nested_project_paths() -> None:
     step = GenericPreparedStep(
-        qualname="test_rule",
+        prefixed_name="test_rule",
         patterns=["*.py"],
         project_path="",
         cmdline=[sys.executable, "-c", "pass"],
@@ -90,7 +90,7 @@ def test_step_match_excludes_nested_project_paths() -> None:
 
 def test_step_errors_when_output_hits_excluded_project_path() -> None:
     step = GenericPreparedStep(
-        qualname="test_rule",
+        prefixed_name="test_rule",
         patterns=["*.py"],
         project_path="",
         cmdline=[

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -1,19 +1,25 @@
 import subprocess
 import sys
 import threading
+from pathlib import Path
+from types import SimpleNamespace
 from typing import Iterable
 
 import pytest
 from feedforward import Notification, Run, State
 from feedforward.step import Step
 
-from ick.base_rule import GenericPreparedStep, match_prefix_patterns
+from ick.base_rule import BaseRule, GenericPreparedStep, match_prefix_patterns
+from ick.cmdline import apply_filters
+from ick.config import MainConfig, RuleConfig, RulesConfig, RuntimeConfig, Settings
+from ick.runner import Runner
+from ick.types_project import BaseRepo
 from ick_protocol import Finished
 
 
 def _step(patterns: list[str], rule_prepare=None) -> GenericPreparedStep:
     return GenericPreparedStep(
-        qualname="test_rule",
+        prefixed_name="test_rule",
         patterns=patterns,
         project_path="",
         cmdline=[sys.executable, "-c", "pass"],
@@ -133,7 +139,7 @@ def test_timeout_in_prepare_run_continues_with_next_step(parallelism: int) -> No
     run = Run(parallelism=parallelism)
     step0 = _step(["*.py"], rule_prepare=failing_prepare)
     step1 = GenericPreparedStep(
-        qualname="test_rule_2",
+        prefixed_name="test_rule_2",
         patterns=["*.txt"],
         project_path="",
         cmdline=[sys.executable, "-c", "import sys; [open(f, 'w').write('modified') for f in sys.argv[1:]]"],
@@ -167,6 +173,45 @@ def test_default_parallelism_is_at_least_two() -> None:
 
     run.run_to_completion({"a": "x", "b": "y"})
     assert not step.cancelled
+
+
+def test_no_rules_found_mentions_legacy_flag_when_it_would_help(capsys) -> None:
+    class DummyRule(BaseRule):
+        def __init__(self, rule_config: RuleConfig) -> None:
+            super().__init__(rule_config)
+
+    rule = RuleConfig(
+        name="rule",
+        impl="dummy",
+        full_name="subdir/rule",
+        prefixed_name="prefix:subdir/rule",
+    )
+    rtc = RuntimeConfig(main_config=MainConfig.DEFAULT, rules_config=RulesConfig(), settings=Settings())
+    runner = Runner(rtc, BaseRepo(root=Path.cwd()))
+    runner.rules = [rule]
+    runner.projects = []
+    apply_filters(
+        SimpleNamespace(obj=SimpleNamespace(filter_config=runner.rtc.filter_config)),
+        ["prefix:subdir/rule"],
+        "",
+        allow_legacy_name_filter=False,
+    )
+
+    def fake_get_impl(_: RuleConfig) -> type[BaseRule]:
+        return DummyRule
+
+    from ick import runner as runner_module
+
+    original_get_impl = runner_module.get_impl
+    runner_module.get_impl = fake_get_impl
+    try:
+        assert list(runner.iter_rule_impl()) == []
+    finally:
+        runner_module.get_impl = original_get_impl
+
+    out = capsys.readouterr().out
+    assert "No rules found" in out
+    assert "--allow-legacy-name-filter" in out
 
 
 def _finished(results: list) -> Finished:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -10,8 +10,8 @@ import textwrap
 from pathlib import Path
 from typing import Iterable
 
-import pytest
 import rich as _rich
+import pytest
 from click.testing import CliRunner
 
 from ick.cmdline import main

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -10,8 +10,8 @@ import textwrap
 from pathlib import Path
 from typing import Iterable
 
-import rich as _rich
 import pytest
+import rich as _rich
 from click.testing import CliRunner
 
 from ick.cmdline import main


### PR DESCRIPTION
This change will allow us to unify the way --isolated-repo works, and
give us the ability to ignore rules only by their rule name in future
repo/project config that doesn't necessarily know what _your_ prefix is.

Where you might `ick run prefix/` you will need to `ick run prefix:` going
forward.  For a transition period there is a fallback to the old style
if the new style doesn't match anything.

If you `ick run abc` now, it will match against `python:abc/foo/bar`
using prefix-path-component rules similar to those we had before, but
across _all_ rulesets instead of a particular one.

You can also still use `-k`