### PR TITLE
Add --json-file flag to ick run for side-effect JSON output

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -104,6 +104,8 @@ ick run --json
 
 # Write JSON results to a file while keeping human-readable output on stdout
 ick run --json-file result.json
+
+# OR: apply changes and also write JSON results to a file
 ick run --apply --json-file result.json
 ```
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -77,6 +77,7 @@ ick run [OPTIONS] [FILTERS]...
 - `-p, --patch` - Show diff of what changes would be made
 - `--apply` - Apply changes made by rule
 - `--json` - JSON output of modifications made by rule (doesn't apply changes)
+- `--json-file FILE` - Write JSON results to a file while showing human-readable output on stdout
 - `--skip-update` - When loading rules from a repo, don't pull if some version already exists locally
 
 Note: Only one of the flags `--dryrun`, `--patch`, and `--apply` can be used at a time.
@@ -100,6 +101,10 @@ ick run now
 
 # Output results as JSON
 ick run --json
+
+# Write JSON results to a file while keeping human-readable output on stdout
+ick run --json-file result.json
+ick run --apply --json-file result.json
 ```
 
 ### `test-rules`

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -186,6 +186,7 @@ def add_rule(
 @click.option("-p", "--patch", is_flag=True, help="Show patches of changes to make")
 @click.option("--apply", is_flag=True, help="Apply changes")
 @click.option("--json", "json_flag", is_flag=True, help="Outputs modifications json by rule qualname (can be used with list-rules --json)")
+@click.option("--json-file", "json_file", type=click.Path(dir_okay=False, writable=True), default=None, help="Write JSON results to a file while showing human-readable output on stdout")
 @click.option("--skip-update", is_flag=True, help="When loading rules from a repo, don't pull if some version already exists locally")
 @click.option("--emojis", is_flag=True, help="Show a waterfall of emojis as work is being done")
 @click.option("--parallelism", type=int, default=0, help="Number of parallel workers (default: auto)")
@@ -199,6 +200,7 @@ def run(
     patch: bool,
     apply: bool,
     json_flag: bool,
+    json_file: str | None,
     skip_update: bool,
     emojis: bool,
     parallelism: int,
@@ -264,21 +266,24 @@ def run(
 
     exit_code = 0
 
+    def _collect_json_result(result: Any, results: dict) -> None:  # type: ignore[type-arg]
+        modifications = []
+        for mod in result.modifications:
+            modifications.append({"file_name": mod.filename, "diff_stat": mod.diffstat})
+        output = {
+            "project_name": result.project,
+            "status": result.finished.status,
+            "modified": modifications,
+            # The meaning of this field depends on the status field above
+            "message": result.finished.message,
+            "metadata": result.finished.metadata,
+        }
+        results[result.rule].append(output)
+
     if json_flag:
         results = collections.defaultdict(list)
         for result in r.run_steps(steps):
-            modifications = []
-            for mod in result.modifications:
-                modifications.append({"file_name": mod.filename, "diff_stat": mod.diffstat})
-            output = {
-                "project_name": result.project,
-                "status": result.finished.status,
-                "modified": modifications,
-                # The meaning of this field depends on the status field above
-                "message": result.finished.message,
-                "metadata": result.finished.metadata,
-            }
-            results[result.rule].append(output)
+            _collect_json_result(result, results)
             if result.finished.status == RuleStatus.ERROR:
                 exit_code = max(exit_code, 2)
             elif result.finished.status == RuleStatus.NEEDS_WORK and question:
@@ -288,7 +293,10 @@ def run(
         sys.stdout.write("\n")
 
     else:
+        json_results: dict | None = collections.defaultdict(list) if json_file else None
         for result in r.run_steps(steps):
+            if json_results is not None:
+                _collect_json_result(result, json_results)
             where = f" on {result.project}" if result.project else ""
             print(f"-> [bold]{fmt_qualname(result.rule, result.prefix)}[/bold]{where}: ", end="")
             match result.finished.status:
@@ -333,6 +341,12 @@ def run(
                         path.parent.mkdir(parents=True, exist_ok=True)
                         path.write_bytes(mod.new_bytes)
                     print(f"   Change made: {mod.filename:30s} {mod.diffstat}")
+
+        if json_results is not None:
+            assert json_file is not None
+            with open(json_file, "w") as f:
+                json.dump({"results": json_results}, f, indent=4, sort_keys=True)
+                f.write("\n")
 
     if exit_code:
         sys.exit(exit_code)

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -24,7 +24,7 @@ from .click_better import FlexibleGroup
 from .config import RuntimeConfig, Settings, load_main_config, load_rules_config, one_repo_config
 from .git import find_repo_root
 from .project_finder import find_projects as find_projects_fn
-from .runner import Runner, _demo_done_callback, _demo_status_callback, fmt_qualname
+from .runner import HighLevelResult, Runner, _demo_done_callback, _demo_status_callback, fmt_qualname
 from .types_project import maybe_repo
 
 
@@ -186,7 +186,7 @@ def add_rule(
 @click.option("-p", "--patch", is_flag=True, help="Show patches of changes to make")
 @click.option("--apply", is_flag=True, help="Apply changes")
 @click.option("--json", "json_flag", is_flag=True, help="Outputs modifications json by rule qualname (can be used with list-rules --json)")
-@click.option("--json-file", "json_file", type=click.Path(dir_okay=False, writable=True), default=None, help="Write JSON results to a file while showing human-readable output on stdout")
+@click.option("--json-file", "json_file", type=click.File(mode="w"), default=None, help="Write JSON results to a file while showing human-readable output on stdout")
 @click.option("--skip-update", is_flag=True, help="When loading rules from a repo, don't pull if some version already exists locally")
 @click.option("--emojis", is_flag=True, help="Show a waterfall of emojis as work is being done")
 @click.option("--parallelism", type=int, default=0, help="Number of parallel workers (default: auto)")
@@ -200,7 +200,7 @@ def run(
     patch: bool,
     apply: bool,
     json_flag: bool,
-    json_file: str | None,
+    json_file: IO[str] | None,
     skip_update: bool,
     emojis: bool,
     parallelism: int,
@@ -266,7 +266,8 @@ def run(
 
     exit_code = 0
 
-    def _collect_json_result(result: Any, results: dict) -> None:  # type: ignore[type-arg]
+    def _collect_json_result(result: HighLevelResult, results_to_modify: dict[str, Any]) -> None:
+        """Collect results into a dict for JSON output."""
         modifications = []
         for mod in result.modifications:
             modifications.append({"file_name": mod.filename, "diff_stat": mod.diffstat})
@@ -278,10 +279,10 @@ def run(
             "message": result.finished.message,
             "metadata": result.finished.metadata,
         }
-        results[result.rule].append(output)
+        results_to_modify[result.rule].append(output)
 
     if json_flag:
-        results = collections.defaultdict(list)
+        results: dict[str, Any] = collections.defaultdict(list)
         for result in r.run_steps(steps):
             _collect_json_result(result, results)
             if result.finished.status == RuleStatus.ERROR:
@@ -293,7 +294,7 @@ def run(
         sys.stdout.write("\n")
 
     else:
-        json_results: dict | None = collections.defaultdict(list) if json_file else None
+        json_results: dict[str, Any] | None = collections.defaultdict(list) if json_file else None
         for result in r.run_steps(steps):
             if json_results is not None:
                 _collect_json_result(result, json_results)
@@ -344,9 +345,8 @@ def run(
 
         if json_results is not None:
             assert json_file is not None
-            with open(json_file, "w") as f:
-                json.dump({"results": json_results}, f, indent=4, sort_keys=True)
-                f.write("\n")
+            json.dump({"results": json_results}, json_file, indent=4, sort_keys=True)
+            json_file.write("\n")
 
     if exit_code:
         sys.exit(exit_code)

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -294,9 +294,9 @@ def run(
         sys.stdout.write("\n")
 
     else:
-        json_results: dict[str, Any] | None = collections.defaultdict(list) if json_file else None
+        json_results = collections.defaultdict(list)
         for result in r.run_steps(steps):
-            if json_results is not None:
+            if json_file is not None:
                 _collect_json_result(result, json_results)
             where = f" on {result.project}" if result.project else ""
             print(f"-> [bold]{fmt_qualname(result.rule, result.prefix)}[/bold]{where}: ", end="")
@@ -343,8 +343,7 @@ def run(
                         path.write_bytes(mod.new_bytes)
                     print(f"   Change made: {mod.filename:30s} {mod.diffstat}")
 
-        if json_results is not None:
-            assert json_file is not None
+        if json_file is not None:
             json.dump({"results": json_results}, json_file, indent=4, sort_keys=True)
             json_file.write("\n")
 

--- a/tests/scenarios/json_file_flag/repo
+++ b/tests/scenarios/json_file_flag/repo
@@ -1,0 +1,1 @@
+../json_flag/repo

--- a/tests/scenarios/json_file_flag/simple.txt
+++ b/tests/scenarios/json_file_flag/simple.txt
@@ -1,0 +1,59 @@
+$ ick run --json-file result.json
+-> do_nothing: OK
+-> fail: ERROR
+     AssertionError
+-> move_a: NEEDS_WORK
+     file_a.cfg -3
+     file_b.toml +3
+-> testpkg/test_import: OK
+(exit status: 2)
+$ cat result.json
+{
+    "results": {
+        "do_nothing": [
+            {
+                "message": "did nothing, but this is a long message anyway:\nlorem ipsum quia dolor sit amet consectetur adipisci velit, sed quia non numquam eius modi tempora incidunt, ut labore et dolore magnam aliquam quaerat voluptatem. Ut enim ad minima veniam, quis nostrum exercitationem ullam corporis suscipit laboriosam, nisi ut aliquid ex ea commodi consequatur? Quis autem vel eum iure reprehenderit, qui in ea voluptate velit esse, quam nihil molestiae consequatur, vel illum, qui dolorem eum fugiat, quo voluptas nulla pariatur.\n",
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "success"
+            }
+        ],
+        "fail": [
+            {
+                "message": "AssertionError\n",
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "error"
+            }
+        ],
+        "move_a": [
+            {
+                "message": "",
+                "metadata": null,
+                "modified": [
+                    {
+                        "diff_stat": "-3",
+                        "file_name": "file_a.cfg"
+                    },
+                    {
+                        "diff_stat": "+3",
+                        "file_name": "file_b.toml"
+                    }
+                ],
+                "project_name": "",
+                "status": "needs-work"
+            }
+        ],
+        "testpkg/test_import": [
+            {
+                "message": "Hello from helper module!\n",
+                "metadata": null,
+                "modified": [],
+                "project_name": "",
+                "status": "success"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `--json-file FILE` option to `ick run` that writes JSON results to a file as a side-effect
- Human-readable output is still shown on stdout as normal (with progress bar support)
- Avoids the need to `ick run --json > result.json` which loses the terminal output
- Refactors the JSON result-building logic into a shared `_collect_json_result` helper

## Usage

```bash
ick run --json-file result.json
ick run --apply --json-file result.json
```

## Test plan

- [ ] New scenario test `tests/scenarios/json_file_flag/simple.txt` verifies human-readable stdout and JSON file contents
- [ ] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)