### PR TITLE
Raise an error when -k is given a value with spaces

### DIFF
--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -351,6 +351,8 @@ main.add_command(
 def apply_filters(ctx: click.Context, filters: list[str], substring: str) -> None:
     if substring and filters:
         raise click.UsageError("Cannot use -k together with positional filters")
+    if substring and " " in substring:
+        raise click.UsageError("-k with spaces is not yet supported")
 
     if not substring and not filters:
         pass

--- a/tests/scenarios/run_some/run_wrong_args.txt
+++ b/tests/scenarios/run_some/run_wrong_args.txt
@@ -10,3 +10,21 @@ Only one of --dry-run, --patch, and --apply can be provided
 $ ick run --dry-run --patch --apply
 Only one of --dry-run, --patch, and --apply can be provided
 (exit status: 1)
+$ ick run -k "foo bar"
+Usage: main run [OPTIONS] [FILTERS]...
+Try 'main run --help' for help.
+
+Error: -k with spaces is not yet supported
+(exit status: 2)
+$ ick list-rules -k "foo bar"
+Usage: main list-rules [OPTIONS] [FILTERS]...
+Try 'main list-rules --help' for help.
+
+Error: -k with spaces is not yet supported
+(exit status: 2)
+$ ick test-rules -k "foo bar"
+Usage: main test-rules [OPTIONS] [FILTERS]...
+Try 'main test-rules --help' for help.
+
+Error: -k with spaces is not yet supported
+(exit status: 2)


### PR DESCRIPTION
My future intent is to (maybe) support `-k "foo or bar"` like pytest does; this makes `-k` options with spaces an error because they're likely to be more confusing than useful now.