### PR TITLE
fix: a test that expects output and gets none should fail

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,17 @@
+# ick
+
+## Running tests
+
+Use `make test` to run the test suite. The sandbox must be disabled because
+tests write to the ick cache directory:
+
+```
+source .venv/bin/activate && make test
+```
+
+Run with `dangerouslyDisableSandbox: true`.
+
+## Scenario tests
+
+See `tests/scenarios/README.md` for how scenario tests work, including how to
+update or create `.txt` files.

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -313,9 +313,9 @@ class Runner:
                     result.message = f"{unchanged_file!r} (unchanged) differs"
                     return
 
+            expected_path = outp / "output.txt"
             if actual_output:
                 # Didn't match expectation
-                expected_path = outp / "output.txt"
                 if not expected_path.exists():
                     result.message = f"Test failed, but {expected_path} doesn't exist so that seems unintended:\n{actual_output}"
                     return
@@ -326,6 +326,13 @@ class Runner:
                 else:
                     result.diff = moreorless.unified_diff(expected, actual_output, "output.txt")
                     result.message = "Different output found"
+                return
+
+            if expected_path.exists():
+                # There was no output, but we expected some
+                expected = expected_path.read_text()
+                result.diff = moreorless.unified_diff(expected, "", "output.txt")
+                result.message = "Expected output, but rule produced none"
                 return
 
         result.success = True

--- a/tests/scenarios/README.md
+++ b/tests/scenarios/README.md
@@ -10,6 +10,11 @@
     - it has tests
         - the tests will only be run if you use `$ ick test-rules` in your
             scenario
-- If you've changed code and it will change scenarios:
+- Do not `cd` into a scenario's `repo` directory to run commands manually;
+  always run from the project root
+- If you've changed code and it will change existing scenarios:
     - you can run the scenarios to auto-update them:
         - `UPDATE_SCENARIOS=1 pytest -k scenario`
+- To create a new scenario `.txt` file:
+    - write a stub containing just the command line (for example: `$ ick test-rules\n`)
+    - then run `UPDATE_SCENARIOS=1 pytest -k scenario` to fill in the expected output

--- a/tests/scenarios/spurious_output_txt/repo/clean_rule.py
+++ b/tests/scenarios/spurious_output_txt/repo/clean_rule.py
@@ -1,0 +1,1 @@
+# This rule does nothing and produces no output.

--- a/tests/scenarios/spurious_output_txt/repo/ick.toml
+++ b/tests/scenarios/spurious_output_txt/repo/ick.toml
@@ -1,0 +1,8 @@
+[[ruleset]]
+path = "."
+
+[[rule]]
+impl = "python"
+name = "clean_rule"
+scope = "project"
+project_types = ["python"]

--- a/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/input/pyproject.toml
+++ b/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/input/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+name = "foo"

--- a/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/output/output.txt
+++ b/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/output/output.txt
@@ -1,0 +1,1 @@
+This output should not have been here!

--- a/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/output/pyproject.toml
+++ b/tests/scenarios/spurious_output_txt/repo/tests/clean_rule/with_spurious_output/output/pyproject.toml
@@ -1,0 +1,2 @@
+[project]
+name = "foo"

--- a/tests/scenarios/spurious_output_txt/test_rules.txt
+++ b/tests/scenarios/spurious_output_txt/test_rules.txt
@@ -1,0 +1,16 @@
+$ ick test-rules
+testing...
+  clean_rule: F FAIL
+
+DETAILS
+--------------------------------------------------------------------------------
+testing clean_rule with with_spurious_output:
+
+Expected output, but rule produced none
+--- a/output.txt
++++ b/output.txt
+@@ -1 +0,0 @@
+-This output should not have been here!
+
+
+(exit status: 1)


### PR DESCRIPTION
Also added more instructions (for people and clankers) about running scenario tests.