### PR TITLE
make file name pattern matching more intuitive

### DIFF
--- a/docs/concepts/scope.md
+++ b/docs/concepts/scope.md
@@ -6,8 +6,8 @@ Regardless of the scope, rules are run in temporary directories with copies of
 the files ick thinks it needs based on the scope and the `inputs` setting.  Your
 rule cannot access files other than those.
 
-You only have access to the files you specify as `input=` -- even specifying
-inefficient globs like `*.py` or `**/scripts/*` is better than leaving it unset
+You only have access to the files you specify as `inputs=` -- even specifying
+inefficient globs like `*.py` or `*/scripts/*` is better than leaving it unset
 which assumes every file gets read.
 
 

--- a/docs/reference/rule_attributes.md
+++ b/docs/reference/rule_attributes.md
@@ -71,10 +71,12 @@ A single `[[rule]]` in an ick.toml can be configured with the following attribut
 
 #### Input/output
 
-These all follow `.gitignore`-like glob patterns, like `*.py`.
-- `inputs` (Sequence[str]): List of input files/patterns.
-- `outputs` (Sequence[str]): List of output files/patterns.
-- `extra_inputs` (Sequence[str]): Additional input files/patterns.
+- `inputs` (Sequence[str]): List of input files/patterns. Simple file name
+    patterns like `*.py` or `data.db` will match file names matching that
+    pattern no matter where they appear in the project. If the pattern has a
+    slash in it, then the directories must also match. `tests/*.py` will only
+    match Python files in the tests directory. `*/data/*.db` will match any .db
+    file in any directory named data anywhere in the project.
 
 #### Metadata
 

--- a/docs/writing-rules/how-rules-are-run.md
+++ b/docs/writing-rules/how-rules-are-run.md
@@ -3,12 +3,12 @@
 When ick runs a rule, it takes these steps:
 
 - Files from your local directory are copied to a temporary directory. Only
-    the files mentioned in the `input` setting will be copied. This is true even
-    for project- and repo-scoped rules, though for those rules `input` defaults
+    the files mentioned in the `inputs` setting will be copied. This is true even
+    for project- and repo-scoped rules, though for those rules `inputs` defaults
     to all files.
 
 - Your rule doesn't run in your local directory, and will only have access to
-    files copied because of the `input` setting.  Each rule gets its own
+    files copied because of the `inputs` setting.  Each rule gets its own
     temporary directory so they can run independently.
 
 - The code of the rule is executed as a separate process.  Different `impl`
@@ -17,8 +17,7 @@ When ick runs a rule, it takes these steps:
     - File-scoped rules get file paths to operate on as *multiple* command-line arguments.
         Their actions should be limited to those files.  Ick might run multiple
         processes for one rule, with different subsets of the requested files
-        passed to each process.  If you also request `extra_inputs` those will
-        be present, but you shouldn't modify them.
+        passed to each process.
 
     - Ick creates environment variables to provide extra information beyond the
         copied files:
@@ -43,8 +42,7 @@ When ick runs a rule, it takes these steps:
         - `ICK_TEST_NAME` is the relative path to the test being run.
 
     - Rules can make changes to the local copies of files, delete files, or
-        create new files.  Any file that might be modified, created, or deleted
-        must be declared in the rule's `outputs` setting.
+        create new files.
 
     - Rules can also make changes beyond the local copies of files.  They might
         change settings in an external service, update databases, or anything at

--- a/ick/base_rule.py
+++ b/ick/base_rule.py
@@ -374,13 +374,40 @@ def analyze_dir(directory: str, expected: Mapping[str, bytes | Erasure]) -> tupl
     return changed, new, remv
 
 
+def _pattern_matches(filename: str, pat: str) -> bool:
+    """Match filename against pat, using basename when pat has no path separator."""
+    if "/" not in pat:
+        filename = filename.rsplit("/", 1)[-1]
+    return fnmatch(filename, pat)
+
+
 def match_prefix_patterns(filename: str, prefix: str, patterns: Sequence[str]) -> str | None:
     """
-    Returns the prefix-removed filename if it matches, otherwise None.
+    Check whether `filename` starts with `prefix` and is matched by one of the
+    `patterns`.
+
+    This is used to check whether a repo-relative file path belongs to a
+    project and matches the rule's ``inputs`` patterns.
+
+    ``prefix`` is the project's subdirectory within the repo (e.g. ``"mylib/"``
+    for a project rooted at ``mylib/``; ``""`` for a repo-root project).
+    ``filename`` is the repo-relative path of the file being considered.
+    ``patterns`` are the glob patterns from the rule's ``inputs`` setting.
+
+    If the file is inside the project *and* matches at least one pattern, the
+    project-relative filename is returned so callers can pass it to the rule
+    command.  Returns ``None`` if the file is outside the project or matches no
+    pattern.
+
+    Pattern matching uses :func:`fnmatch.fnmatch` semantics.  Patterns that
+    contain no ``/`` are matched against the bare filename (so ``tox.ini``
+    matches ``subdir/tox.ini``).  Patterns that contain ``/`` are matched
+    against the full project-relative path (so ``src/*.py`` matches only files
+    directly inside ``src/``).
     """
     if filename.startswith(prefix):
         filename = filename[len(prefix) :].lstrip("/")
-        if any(fnmatch(filename, pat) for pat in patterns):
+        if any(_pattern_matches(filename, pat) for pat in patterns):
             return filename
     return None
 

--- a/ick/cmdline.py
+++ b/ick/cmdline.py
@@ -186,7 +186,13 @@ def add_rule(
 @click.option("-p", "--patch", is_flag=True, help="Show patches of changes to make")
 @click.option("--apply", is_flag=True, help="Apply changes")
 @click.option("--json", "json_flag", is_flag=True, help="Outputs modifications json by rule qualname (can be used with list-rules --json)")
-@click.option("--json-file", "json_file", type=click.File(mode="w"), default=None, help="Write JSON results to a file while showing human-readable output on stdout")
+@click.option(
+    "--json-file",
+    "json_file",
+    type=click.File(mode="w"),
+    default=None,
+    help="Write JSON results to a file while showing human-readable output on stdout",
+)
 @click.option("--skip-update", is_flag=True, help="When loading rules from a repo, don't pull if some version already exists locally")
 @click.option("--emojis", is_flag=True, help="Show a waterfall of emojis as work is being done")
 @click.option("--parallelism", type=int, default=0, help="Number of parallel workers (default: auto)")

--- a/ick/runner.py
+++ b/ick/runner.py
@@ -28,6 +28,7 @@ from .config import RuntimeConfig
 from .config.rule_repo import discover_rules, get_impl
 from .project_finder import find_projects
 from .types_project import BaseRepo, Project, Repo, maybe_repo
+from .util import clean_output
 
 LOG = getLogger(__name__)
 
@@ -69,9 +70,6 @@ class TestResult:
 
 
 class Runner:
-    # Strings to replace in outputs while running scenario tests.
-    _testing_replacements: dict[str, str] = {}
-
     def __init__(self, rtc: RuntimeConfig, repo: Repo, parallelism: int = 0) -> None:
         self.rtc = rtc
         self.rules = discover_rules(rtc)
@@ -255,8 +253,6 @@ class Runner:
             response = run_result.modifications
 
             actual_output = run_result.finished.message
-            for old, new in self._testing_replacements.items():
-                actual_output = actual_output.replace(old, new)
 
             if update:
                 changed = self._write_update(inp, outp, response, run_result.finished.status, actual_output)
@@ -276,11 +272,12 @@ class Runner:
                     result.message = f"Test crashed, but {expected_path} doesn't exist so that seems unintended:\n{actual_output}"
                     return
 
-                expected = expected_path.read_text()
-                if expected == actual_output:
+                expected = clean_output(expected_path.read_text())
+                output = clean_output(actual_output)
+                if expected == output:
                     result.success = True
                 else:
-                    result.diff = moreorless.unified_diff(expected, actual_output, "error.txt")
+                    result.diff = moreorless.unified_diff(expected, output, "error.txt")
                     result.message = "Different output found"
                 return
 

--- a/ick/util.py
+++ b/ick/util.py
@@ -1,3 +1,5 @@
+import os
+import re
 from collections.abc import Sequence
 from pathlib import Path
 
@@ -100,3 +102,22 @@ def diffstat(diff_text: str) -> str:
 
 def convert_path_to_python_identifiers(path: Path) -> Path:
     return Path(*[part.replace("-", "_") for part in path.parts])
+
+
+TRACEBACK_LINE_NUM_RE = re.compile(r"(, line )\d+(,)")
+LOG_LINE_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} ", re.M)
+LOG_LINE_NUMERIC_LINE_RE = re.compile(r"^([A-Z]+\s+[a-z_.]+:)\d+(?= )", re.M)
+GIT_VERSION_RE = re.compile(r"(\d+\.)\d+(?:\.\d+)?(?:\.dev\d+\S+)?")
+TRAILING_WHITESPACE = re.compile(r"(?m) +$")
+ICK_OUTPUT_DIR_RE = re.compile(r"ICK_OUTPUT_DIR=\S+")
+
+
+def clean_output(output: str) -> str:
+    cleaned_output = TRACEBACK_LINE_NUM_RE.sub(r"\1<n>\2", output)
+    cleaned_output = LOG_LINE_TIMESTAMP_RE.sub("", cleaned_output)
+    cleaned_output = LOG_LINE_NUMERIC_LINE_RE.sub(r"\1<n>", cleaned_output)
+    cleaned_output = GIT_VERSION_RE.sub(r"\1<stuff>", cleaned_output)
+    cleaned_output = TRAILING_WHITESPACE.sub("", cleaned_output)
+    cleaned_output = cleaned_output.replace(os.getcwd(), "/CWD")
+    cleaned_output = ICK_OUTPUT_DIR_RE.sub("ICK_OUTPUT_DIR=<tmp>", cleaned_output)
+    return cleaned_output

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -7,7 +7,7 @@ import pytest
 from feedforward import Notification, Run, State
 from feedforward.step import Step
 
-from ick.base_rule import GenericPreparedStep
+from ick.base_rule import GenericPreparedStep, match_prefix_patterns
 from ick_protocol import Finished
 
 
@@ -21,6 +21,50 @@ def _step(patterns: list[str], rule_prepare=None) -> GenericPreparedStep:
         append_filenames=True,
         rule_prepare=rule_prepare,
     )
+
+
+def test_pattern_without_slash_matches_basename_anywhere() -> None:
+    assert match_prefix_patterns("tox.ini", "", ["tox.ini"]) == "tox.ini"
+    assert match_prefix_patterns("subdir/tox.ini", "", ["tox.ini"]) == "subdir/tox.ini"
+    assert match_prefix_patterns("a/b/tox.ini", "", ["tox.ini"]) == "a/b/tox.ini"
+    assert match_prefix_patterns("not-tox.ini", "", ["tox.ini"]) is None
+    assert match_prefix_patterns("foo.py", "", ["*.py"]) == "foo.py"
+    assert match_prefix_patterns("src/foo.py", "", ["*.py"]) == "src/foo.py"
+    assert match_prefix_patterns("src/foo.txt", "", ["*.py"]) is None
+
+
+def test_pattern_with_slash_matches_full_path() -> None:
+    assert match_prefix_patterns("src/foo.py", "", ["src/*.py"]) == "src/foo.py"
+    assert match_prefix_patterns("foo.py", "", ["src/*.py"]) is None
+    assert match_prefix_patterns("other/foo.py", "", ["src/*.py"]) is None
+
+
+def test_file_outside_prefix_never_matches() -> None:
+    assert match_prefix_patterns("other/foo.py", "mylib/", ["*.py"]) is None
+
+
+def test_prefix_stripped_from_returned_filename() -> None:
+    assert match_prefix_patterns("mylib/src/foo.py", "mylib/", ["*.py"]) == "src/foo.py"
+    assert match_prefix_patterns("mylib/tox.ini", "mylib/", ["tox.ini"]) == "tox.ini"
+    assert match_prefix_patterns("mylib/subdir/tox.ini", "mylib/", ["tox.ini"]) == "subdir/tox.ini"
+
+
+def test_any_pattern_in_list_can_match() -> None:
+    assert match_prefix_patterns("tox.ini", "", ["*.py", "tox.ini"]) == "tox.ini"
+    assert match_prefix_patterns("foo.py", "", ["*.py", "tox.ini"]) == "foo.py"
+    assert match_prefix_patterns("setup.cfg", "", ["*.py", "tox.ini"]) is None
+
+
+def test_double_star_is_not_special() -> None:
+    # ** has no special meaning; it behaves identically to *.
+    # */scripts/* matches scripts/ preceded by at least one path component.
+    assert match_prefix_patterns("foo/scripts/run.sh", "", ["*/scripts/*"]) == "foo/scripts/run.sh"
+    assert match_prefix_patterns("a/b/scripts/run.sh", "", ["*/scripts/*"]) == "a/b/scripts/run.sh"
+    assert match_prefix_patterns("foo/scripts/run.sh", "", ["**/scripts/*"]) == "foo/scripts/run.sh"
+    assert match_prefix_patterns("a/b/scripts/run.sh", "", ["**/scripts/*"]) == "a/b/scripts/run.sh"
+    # Neither form matches scripts/ at the project root (no leading path component).
+    assert match_prefix_patterns("scripts/run.sh", "", ["*/scripts/*"]) is None
+    assert match_prefix_patterns("scripts/run.sh", "", ["**/scripts/*"]) is None
 
 
 def test_step_match_excludes_nested_project_paths() -> None:

--- a/tests/test_scenarios.py
+++ b/tests/test_scenarios.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import dataclasses
 import os
-import re
 import shlex
 import shutil
 import subprocess
@@ -16,27 +15,10 @@ import rich as _rich
 from click.testing import CliRunner
 
 from ick.cmdline import main
+from ick.util import clean_output
 
 SCENARIO_DIR = Path(__file__).parent / "scenarios"
 SCENARIOS = sorted(str(f.relative_to(SCENARIO_DIR)) for f in SCENARIO_DIR.glob("*/*.txt"))
-
-LOG_LINE_TIMESTAMP_RE = re.compile(r"^\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2},\d{3} ", re.M)
-LOG_LINE_NUMERIC_LINE_RE = re.compile(r"^([A-Z]+\s+[a-z_.]+:)\d+(?= )", re.M)
-TRACEBACK_LINE_NUM_RE = re.compile(r"(, line )\d+(,)")
-GIT_VERSION_RE = re.compile(r"(\d+\.)\d+(?:\.\d+)?(?:\.dev\d+\S+)?")
-TRAILING_WHITESPACE = re.compile(r"(?m) +$")
-ICK_OUTPUT_DIR_RE = re.compile(r"ICK_OUTPUT_DIR=\S+")
-
-
-def clean_output(output: str) -> str:
-    cleaned_output = TRACEBACK_LINE_NUM_RE.sub(lambda m: (m.group(1) + "<n>" + m.group(2)), output)
-    cleaned_output = LOG_LINE_TIMESTAMP_RE.sub("", cleaned_output)
-    cleaned_output = LOG_LINE_NUMERIC_LINE_RE.sub(lambda m: (m.group(1) + "<n>"), cleaned_output)
-    cleaned_output = GIT_VERSION_RE.sub(lambda m: (m.group(1) + "<stuff>"), cleaned_output)
-    cleaned_output = TRAILING_WHITESPACE.sub("", cleaned_output)
-    cleaned_output = cleaned_output.replace(os.getcwd(), "/CWD")
-    cleaned_output = ICK_OUTPUT_DIR_RE.sub("ICK_OUTPUT_DIR=<tmp>", cleaned_output)
-    return cleaned_output
 
 
 @pytest.mark.parametrize("filename", SCENARIOS)
@@ -84,14 +66,7 @@ def test_scenario(filename, monkeypatch) -> None:  # type: ignore[no-untyped-def
             if command.command[:6] == "$ ick ":
                 # TODO: handle global options like -vv
                 args = shlex.split(command.command[6:])
-                with monkeypatch.context() as m:
-                    m.setattr(
-                        "ick.runner.Runner._testing_replacements",
-                        {
-                            os.getcwd(): "/CWD",
-                        },
-                    )
-                    result = cli_runner.invoke(main, args, catch_exceptions=False)
+                result = cli_runner.invoke(main, args, catch_exceptions=False)
                 output = result.output
                 if result.exit_code != 0:
                     output += f"(exit status: {result.exit_code})\n"


### PR DESCRIPTION
Previously, `inputs=["*.py"]` matched .py files anywhere in the project, but `inputs=["tox.ini"]` only matched tox.ini files in the root.  Now both will match anywhere in the project.

Also improved the documentation for the `inputs=` setting, and removed mention of `extra_inputs` and `outputs`, neither of which is implemented yet.

