### PR TITLE
Handle get_impl errors a lot more gracefully

### DIFF
--- a/ick/runner.py
+++ b/ick/runner.py
@@ -69,6 +69,30 @@ class TestResult:
     traceback: str = ""
 
 
+class ErrorRule(BaseRule):
+    """Synthetic rule yielded when a rule impl raises during instantiation."""
+
+    def __init__(self, rule_config: Any, error: str) -> None:
+        super().__init__(rule_config)
+        self.runnable = False
+        self.status = error
+
+    def add_steps_to_run(self, projects: Any, env: Any, run: Run[str, bytes | Erasure]) -> None:
+        step = GenericPreparedStep(
+            qualname=self.rule_config.qualname,
+            patterns=("*",),
+            project_path="",
+            cmdline=[],
+            extra_env={},
+            append_filenames=False,
+            prefix=self.rule_config.prefix or "",
+            eager=False,
+            batch_size=-1,
+        )
+        run.add_step(step)
+        step.cancel(self.status)
+
+
 class Runner:
     def __init__(self, rtc: RuntimeConfig, repo: Repo, parallelism: int = 0) -> None:
         self.rtc = rtc
@@ -97,7 +121,10 @@ class Runner:
                 continue
 
             rules_matched += 1
-            yield get_impl(rule)(rule)
+            try:
+                yield get_impl(rule)(rule)
+            except Exception as e:
+                yield ErrorRule(rule, str(e))
 
         if rules_matched == 0 and len(self.rules) > 0:
             print(

--- a/tests/scenarios/hyphen_in_rule_path/hyphen_in_rule_path.txt
+++ b/tests/scenarios/hyphen_in_rule_path/hyphen_in_rule_path.txt
@@ -1,0 +1,5 @@
+$ ick run
+-> galactic-empire/foundation_series/foundation_series: ERROR
+     Path PosixPath('galactic-empire/foundation_series/foundation_series.py') contains invalid Python identifiers
+-> good: OK
+(exit status: 2)

--- a/tests/scenarios/hyphen_in_rule_path/repo/galactic-empire/foundation_series/ick.toml
+++ b/tests/scenarios/hyphen_in_rule_path/repo/galactic-empire/foundation_series/ick.toml
@@ -1,0 +1,5 @@
+[[rule]]
+name = "foundation_series"
+impl = "python"
+scope = "project"
+project_types = ["python"]

--- a/tests/scenarios/hyphen_in_rule_path/repo/ick.toml
+++ b/tests/scenarios/hyphen_in_rule_path/repo/ick.toml
@@ -1,0 +1,9 @@
+[[ruleset]]
+path = "."
+
+[[rule]]
+name = "good"
+impl = "shell"
+scope = "repo"
+data = "true"
+urgency = "now"

--- a/tests/scenarios/hyphen_in_rule_path/repo/pyproject.toml
+++ b/tests/scenarios/hyphen_in_rule_path/repo/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools"]


### PR DESCRIPTION
Unlike config loading, this was fatal to the run before (because no steps would actually get run).  This treats it the same as a run that immediately crashes (which is a whole lot better for reporting).