### PR TITLE
Added tagging rulesets

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,9 @@ but it's OK for hard things to still be hard.
 
 ### Unreleased
 
+- `[[ruleset]]` can set `tags`, which are applied to every rule in that
+  ruleset.
+
 - The `ICK_COVERAGE_PY` setting could re-use virtualenvs configured to write
   coverage data files into incorrect directories. This is now fixed.
 

--- a/docs/reference/rule_attributes.md
+++ b/docs/reference/rule_attributes.md
@@ -13,6 +13,8 @@ The following attributes can be set in an `ick.toml` or `pyproject.toml`.
 
 - `prefix` (str): A prefix to use for the rules from this ruleset. If not
   specified, it will be derived from the last component of the URL or path.
+- `tags` (list[str]): Labels applied to every rule loaded from this ruleset.
+    Combined with each rule's own `tags`.
 
 
 ## `[[rule]]` attributes

--- a/ick/config/rule_repo.py
+++ b/ick/config/rule_repo.py
@@ -121,6 +121,7 @@ def load_rule_repo(ruleset: Ruleset) -> RuleRepoConfig:
             rule.repo_path = repo_path
             if not rule.url:
                 rule.url = ruleset.url
+            rule.tags = [*ruleset.tags, *rule.tags]
 
         rc.inherit(c)
 

--- a/ick/config/rules.py
+++ b/ick/config/rules.py
@@ -52,6 +52,7 @@ class Ruleset(Struct):
 
     prefix: Optional[str] = None
     base_path: Optional[Path] = None  # Dir of the config that referenced this
+    tags: Sequence[str] = ()
 
     repo: Optional[RuleRepoConfig] = None
 

--- a/tests/scenarios/tags/list_rules_by_tag.txt
+++ b/tests/scenarios/tags/list_rules_by_tag.txt
@@ -16,3 +16,10 @@ $ ick list-rules -t lint python-rule
 NOW
 ===
 * python-rule
+#
+$ ick list-rules -t demo
+NOW
+===
+* python-rule
+* security-rule
+* untagged-rule

--- a/tests/scenarios/tags/repo/ick.toml
+++ b/tests/scenarios/tags/repo/ick.toml
@@ -1,5 +1,6 @@
 [[ruleset]]
 path = "."
+tags = ["demo"]
 
 [[rule]]
 impl = "shell"

--- a/tests/test_rules_tagging.py
+++ b/tests/test_rules_tagging.py
@@ -1,0 +1,35 @@
+from pathlib import Path
+
+from ick.config.rule_repo import load_rule_repo
+from ick.config.rules import Ruleset
+
+
+def test_load_rule_repo_propagates_ruleset_tags(tmp_path: Path) -> None:
+    (tmp_path / "ick.toml").write_text(
+        """\
+[[rule]]
+name = "hello"
+impl = "shell"
+command = "true"
+tags = ["rule-tag"]
+"""
+    )
+    r = Ruleset(path=tmp_path.as_posix(), prefix="demo", tags=["team", "mandatory"])
+    rc = load_rule_repo(r)
+    assert list(rc.rule[0].tags) == ["team", "mandatory", "rule-tag"]
+
+
+def test_load_rule_repo_preserves_existing_tags(tmp_path: Path) -> None:
+    (tmp_path / "ick.toml").write_text(
+        """\
+[[rule]]
+name = "tagged"
+impl = "shell"
+command = "true"
+tags = ["security", "python"]
+"""
+    )
+    r = Ruleset(path=tmp_path.as_posix(), prefix="myrules")
+    rc = load_rule_repo(r)
+    assert len(rc.rule) == 1
+    assert list(rc.rule[0].tags) == ["security", "python"]


### PR DESCRIPTION
### Add support for ruleset-level tags 

This PR adds the ability to set tags at the [[ruleset]] level in ick.toml / pyproject.toml. Any tags defined on a ruleset are automatically inherited by every rule loaded from it.

#### What's changed:

  • Added tags field to [[ruleset]] config (Ruleset struct).
  • Updated load_rule_repo to prepending ruleset tags to each rule's own tags ([*ruleset.tags, *rule.tags]).
  • Updated docs (README.md & rule_attributes.md).
  • Added unit and scenario tests for filtering by ruleset tags.
  
  
  WDYT?